### PR TITLE
Don't use a Gargoyle-internal function

### DIFF
--- a/src/jacl.c
+++ b/src/jacl.c
@@ -38,7 +38,6 @@
 #ifndef GARGLK
 #include "glkterm/gi_blorb.h"
 #include "glkterm/glk.h"
-#include "Gargoyle/garglk.h"
 #endif
 
 glui32 				status_width, status_height;
@@ -168,6 +167,11 @@ static char* object_generator(const char* text, int state);
 static char* verb_generator(const char* text, int state);
 static void add_word(const char * word);
 #endif
+
+static void jacl_strict_warning(const char *msg)
+{
+	fprintf(stderr, "JACL error: %s\n", msg);
+}
 
 void
 glk_main(void)
@@ -1575,12 +1579,12 @@ parse_utf8(unsigned char *buf, glui32 buflen,
 
         if ((val0 & 0xe0) == 0xc0) {
             if (pos+1 > buflen) {
-                gli_strict_warning("incomplete two-byte character");
+                jacl_strict_warning("incomplete two-byte character");
                 break;
             }
             val1 = buf[pos++];
             if ((val1 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed two-byte character");
+                jacl_strict_warning("malformed two-byte character");
                 break;
             }
             res = (val0 & 0x1f) << 6;
@@ -1591,17 +1595,17 @@ parse_utf8(unsigned char *buf, glui32 buflen,
 
         if ((val0 & 0xf0) == 0xe0) {
             if (pos+2 > buflen) {
-                gli_strict_warning("incomplete three-byte character");
+                jacl_strict_warning("incomplete three-byte character");
                 break;
             }
             val1 = buf[pos++];
             val2 = buf[pos++];
             if ((val1 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed three-byte character");
+                jacl_strict_warning("malformed three-byte character");
                 break;
             }
             if ((val2 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed three-byte character");
+                jacl_strict_warning("malformed three-byte character");
                 break;
             }
             res = (((val0 & 0xf)<<12)  & 0x0000f000);
@@ -1613,26 +1617,26 @@ parse_utf8(unsigned char *buf, glui32 buflen,
 
         if ((val0 & 0xf0) == 0xf0) {
             if ((val0 & 0xf8) != 0xf0) {
-                gli_strict_warning("malformed four-byte character");
+                jacl_strict_warning("malformed four-byte character");
                 break;        
             }
             if (pos+3 > buflen) {
-                gli_strict_warning("incomplete four-byte character");
+                jacl_strict_warning("incomplete four-byte character");
                 break;
             }
             val1 = buf[pos++];
             val2 = buf[pos++];
             val3 = buf[pos++];
             if ((val1 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed four-byte character");
+                jacl_strict_warning("malformed four-byte character");
                 break;
             }
             if ((val2 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed four-byte character");
+                jacl_strict_warning("malformed four-byte character");
                 break;
             }
             if ((val3 & 0xc0) != 0x80) {
-                gli_strict_warning("malformed four-byte character");
+                jacl_strict_warning("malformed four-byte character");
                 break;
             }
             res = (((val0 & 0x7)<<18)   & 0x1c0000);
@@ -1643,7 +1647,7 @@ parse_utf8(unsigned char *buf, glui32 buflen,
             continue;
         }
 
-        gli_strict_warning("malformed character");
+        jacl_strict_warning("malformed character");
     }
 
     return outpos;

--- a/src/jacl.h
+++ b/src/jacl.h
@@ -22,10 +22,6 @@
 #include "gi_blorb.h"
 #endif
 
-#ifdef GARGLK
-#include "garglk.h"
-#endif
-
 #ifdef FCGIJACL
 #include <fcgi_stdio.h>
 #endif


### PR DESCRIPTION
gli_strict_warning is internal to Gargoyle, and is not meant for
external use. I'm planning on switching Gargoyle to C++, which will
result in garglk.h only working with C++ (it will expose an empty file,
effectively, to C code).

Since gli_strict_warning simply dumps the message to stderr, I've
created a JACL-specific function to do the same thing here, so the
behavior should be the same.