### PR TITLE
Fix media loading in Gargoyle

### DIFF
--- a/src/jacl.c
+++ b/src/jacl.c
@@ -35,6 +35,10 @@
 #include "parser.h"
 #include "encapsulate.h"
 
+#ifdef GARGLK
+#include <glkstart.h>
+#endif
+
 #ifndef GARGLK
 #include "glkterm/gi_blorb.h"
 #include "glkterm/glk.h"
@@ -137,7 +141,7 @@ strid_t inputstr = NULL;
 
 char            user_id[] = "local";
 char            prefix[81] = "\0";
-char            blorb[81] = "\0";
+char            blorb[256] = "\0";
 char            game_path[256] = "\0";
 char            game_file[256] = "\0";
 char            processed_file[256] = "\0";
@@ -221,7 +225,15 @@ glk_main(void)
 
 	/* OPEN THE BLORB FILE IF ONE EXISTS */
 #ifndef WINGLK
+#ifdef GARGLK
+	// Per the Glk spec, Gargoyle appends ".glkdata" to files opened via the
+	// "normal" Glk routines (e.g. glk_fileref_create_by_name). JACL assumes
+	// that it can open arbitrary files, and for that,
+	// glkunix_stream_open_pathname is required.
+	blorb_stream = glkunix_stream_open_pathname(blorb, 0, 0);
+#else
 	blorb_file = glk_fileref_create_by_name(fileusage_BinaryMode, blorb, 0);
+#endif
 #else
 	strcpy(temp_buffer, game_path);
 	strcat(temp_buffer, blorb);
@@ -229,8 +241,13 @@ glk_main(void)
 	blorb_file = winglk_fileref_create_by_name(fileusage_BinaryMode, blorb, 0, 0);
 #endif
 
+	// glkunix_stream_open_pathname does all this already.
+#ifndef GARGLK
 	if (blorb_file != NULL && glk_fileref_does_file_exist(blorb_file)) {
 		blorb_stream = glk_stream_open_file(blorb_file, filemode_Read, 0);
+#else
+        {
+#endif
 
 		if (blorb_stream != NULL) {
 			/* IF THE FILE EXISTS, SET THE RESOURCE MAP */

--- a/src/utils.c
+++ b/src/utils.c
@@ -142,7 +142,14 @@ create_paths(char *full_path)
 	sprintf(bookmark, "%s.bookmark", prefix);
 
 	/* SET DEFAULT BLORB FILE NAME */
+#ifdef GARGLK
+	// Gargoyle uses glkunix_stream_open_pathname to open this file, but
+	// it's not (necessarily) going to be in the current working directory,
+	// so provide the full path.
+	sprintf(blorb, "%s/%s.blorb", game_path, prefix);
+#else
 	sprintf(blorb, "%s.blorb", prefix);
+#endif
 #endif
 
 	/* SET DEFAULT FILE LOCATIONS IF NOT SET BY THE USER IN CONFIG */


### PR DESCRIPTION
Gargoyle's behavior recently changed to follow Glk recommendations
regarding filenames, breaking JACL's assumption about filenames. Glk
doesn't guarantee arbitrary file access, which JACL relied on. However,
Gargoyle does provide the glkunix_stream_open_pathname function as an
extension, which _does_ allow for arbitrary file access, so that's used
now.