### PR TITLE
Convert to char* for strlen

### DIFF
--- a/src/jacl.c
+++ b/src/jacl.c
@@ -1541,7 +1541,7 @@ convert_to_utf32 (unsigned char *text)
 	    return 0;
 	}
 
-	text_len = strlen(text);
+	text_len = strlen((char *)text);
 
 	if (!text_len) {
 	    return 0;


### PR DESCRIPTION
strlen expects a char*, not unsigned char*. Passing unsigned char* is
technically a constraint violation (compilers are free to reject it),
though in practice it will result in a warning. But the warning is
correct, and this cast silences it.

A better approach may be to switch things around so that char* is used
throughout, instead of casting, but that's a more involved change.