### PR TITLE
Make current_command char*, not const char*

### DIFF
--- a/src/jacl.c
+++ b/src/jacl.c
@@ -81,7 +81,7 @@ static char		oops_buffer[1024];
 static char		oopsed_current[1024];
 char            last_command[1024];
 char			*blank_command = "blankjacl\0";
-static const char            *current_command = (char *) NULL;
+static char            *current_command = NULL;
 static char		command_buffer[1024];
 #ifndef NOUNICODE
 static glui32	command_buffer_uni[1024];


### PR DESCRIPTION
This is used as the target of strcpy(), so cannot be const.