### PR TITLE
Add strings.h for strcasecmp

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -13,6 +13,7 @@
 #include "parser.h"
 #include "encapsulate.h"
 #include <string.h>
+#include <strings.h>
 #include <unistd.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
strcasecmp is a POSIX function, not standard C, and is declared in strings.h, not string.h.