### PR TITLE
Prefer _WIN32 to WIN32

### DIFF
--- a/src/cgijacl.c
+++ b/src/cgijacl.c
@@ -147,7 +147,7 @@ main(int argc, char *argv[])
 
     strcpy(temp_buffer, argv[1]);
 
-#ifdef WIN32
+#ifdef _WIN32
     /* THIS CODE CONVERTS ALL FORWARD SLASHES TO BACK SLASHES AND IS
      * REQUIRED WHEN COMPILING FOR MS WINDOWS USING VISUAL C++ */
 

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -16,7 +16,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 struct flock {
     short l_type;
     short l_whence;
@@ -39,7 +39,7 @@ struct flock {
 #define F_UNLCK  2
 
 int fcntl(int __fd, int __cmd, ...) { return 0; }
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #ifndef strcasestr
 char *strcasestr(const char *s, const char *find)

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -18,7 +18,7 @@
 
 #include "csv.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifndef GARGLK
 #include <windows.h>
 #include "glkterm/glk.h"

--- a/src/jacl.h
+++ b/src/jacl.h
@@ -32,14 +32,12 @@
 #define M_PI        3.14159265358979323846
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #define DIR_SEPARATOR '\\'
 #define TEMP_DIR "temp\\"
 #define DATA_DIR "data\\"
 #define INCLUDE_DIR "include\\"
-#endif
-
-#ifndef WIN32
+#else
 #define DIR_SEPARATOR '/'
 #define DATA_DIR "data/"
 #define TEMP_DIR "temp/"

--- a/src/jpp.c
+++ b/src/jpp.c
@@ -176,11 +176,7 @@ process_file(const char *sourceFile1, const char *sourceFile2)
 			if (!encrypting && *stripped_line != '#' && *stripped_line != '\0' && do_encrypt & release) {
 				/* START ENCRYPTING FROM THE FIRST NON-COMMENT LINE IN
 				 * THE SOURCE FILE */
-#ifdef WIN32
-				fputs("#encrypted\r\n", outputFile);
-#else
 				fputs("#encrypted\n", outputFile);
-#endif
 				encrypting = TRUE;
 			} 
 
@@ -193,11 +189,7 @@ process_file(const char *sourceFile1, const char *sourceFile2)
 
 			lines_written++;
 			if (lines_written == 1) {
-#ifdef WIN32
-				sprintf(temp_buffer, "#processed:%d\r\n", INTERPRETER_VERSION);
-#else
 				sprintf(temp_buffer, "#processed:%d\n", INTERPRETER_VERSION);
-#endif
 				fputs(temp_buffer, outputFile);
 			}
 		}

--- a/src/utils.c
+++ b/src/utils.c
@@ -195,7 +195,7 @@ stripwhite (char *string)
 
 	while (i >= 0 && ((jacl_whitespace (*(string+ i))) || *(string + i) == '\n' || *(string + i) == '\r')) i--;
 
-#ifdef WIN32
+#ifdef _WIN32
     i++;
 	*(string + i) = '\r';
 #endif


### PR DESCRIPTION
_WIN32 is defined by the compiler and should exist whenever JACL is built on Windows. I'm no Windows expert, but it seems that WIN32 is an oddity. It's defined by some Windows headers, which means it won't exist till windows.h (or something else) is included. As it stands, it seems that JACL expects WIN32 to be defined by the build system when on Windows.

My rationale here is that a Windows compiler already knows it's on Windows, making the need to tell it so redundant. Things will be less fragile if _WIN32 is checked, since it requires no user intervention.

This also completely removes a couple lines for Windows that write "\r\n" instead of "\n" at the end of a line: the file being written to is opened in text mode (using "w", not "wb"). In text mode, newline translation is already done by the C library. Writing "\n" will cause the Windows stdio implementation to write out "\r\n" (and likewise, a "\r\n" when read is converted to "\n"). So the manual writing of CR is unnecessary, even on Windows.