### PR TITLE
Update user guide to document all interpreter commands

### DIFF
--- a/guide/csv.html
+++ b/guide/csv.html
@@ -132,6 +132,40 @@ append data last_id firstname_data surname_data email_data home_phone_data mobil
 write firstname_data " " surname_data " added to database.^^"
 </pre>
 
+<h2><a class="section" name="csv4">The APPEND_FC, APPEND_NT and APPEND_LC Commands</a></h2>
+
+<p>These three commands are used together to build a single CSV row incrementally across multiple commands. This is useful when the number of columns in a row is not known in advance, such as when iterating over a variable-length data set.
+
+<p>The commands use the following format:
+
+<pre>
+<B>append_fc</B> <I>&lt;FileName&gt;</I> <I>&lt;Field0&gt;</I> [<I>&lt;Field1&gt;</I>...]
+<B>append_nt</B> <I>&lt;FileName&gt;</I> <I>&lt;Field0&gt;</I> [<I>&lt;Field1&gt;</I>...]
+<B>append_lc</B> <I>&lt;FileName&gt;</I> <I>&lt;Field0&gt;</I> [<I>&lt;Field1&gt;</I>...]
+</pre>
+
+<p>The <b>append_fc</b> (first column) command starts a new line in the CSV file and writes the specified fields. It does not terminate the line, leaving it open for further fields to be added.
+
+<p>The <b>append_nt</b> (no terminate) command continues writing fields to the current open line without terminating it. This command can be called multiple times to add additional columns.
+
+<p>The <b>append_lc</b> (last column) command continues writing fields to the current open line and then terminates the line with a newline character, closing the file.
+
+<p>Below is an example of these three commands being used together to build a row with a variable number of columns:
+
+<pre>
+append_fc results date time name
+iterate data skip_header
+   if COUNT &lt; obs_count
+      append_nt results observations[INDEX]
+      set COUNT + 1
+   else
+      append_lc results observations[INDEX]
+   endif
+enditerate
+</pre>
+
+<p>In this example, <b>append_fc</b> starts the row with three fixed columns. The <b>iterate</b> loop then adds a variable number of observation columns using <b>append_nt</b>, with the final column being written using <b>append_lc</b> to close the line.
+
 <!-- END OF BODY -->
 <p><a href="index.html">Back to Contents</b>
 </body>

--- a/guide/flowcontrol.html
+++ b/guide/flowcontrol.html
@@ -9,7 +9,7 @@
 
 <h1><a class="title" name="flowcontrol0">Flow Control</a></h1>
 
-<h2><a class="section" name="flowcontrol1">The IF, IFALL and ENDIF Commands</a></h2>
+<h2><a class="section" name="flowcontrol1">The IF, IFALL, ENDIF and ENDALL Commands</a></h2>
 
 <P>An <b>if</b> command tests whether an expression is true or false for the purpose of selectively executing code. If the expression is true, execution will continue from the next line. If the expression is false, execution will continue from the line after the matching <b>endif</b> or <b>else</b> command. If no <b>endif</b> command is found by the end of the function, the function will terminate normally with an implicit <b>return true</b>. An <b>if</b> command must be of the format:
 
@@ -134,6 +134,18 @@ if sword(parent) = field
 
 <P>It is possible to nest <B>if</B> statements. Nesting involves placing a second <B>if</B> command before the matching <B>endif</B> command of a first. The end result of this is that the code between the second <B>if</B> command and its matching <B>endif</B> command will only be executed if both statements are true &mdash; a logical <b>AND</b>.
 
+<p>The <b>endall</b> command can be used to exit all nested conditional blocks at once by immediately resetting the nesting level to zero. This is useful when deeply nested <b>if</b> statements all need to be exited at a certain point without requiring a matching <b>endif</b> for each level. For example:
+
+<pre>
+if condition1
+   if condition2
+      if condition3
+         write "All three conditions are true.^"
+      endall
+</pre>
+
+<p>In the above code, the <b>endall</b> command exits all three <b>if</b> blocks at once, removing the need for three separate <b>endif</b> commands.
+
 <h2><a class="section" name="flowcontrol2">The IFSTRING Command</a></h2>
 
 <p>An <b>ifstring</b> command is used to compare two strings of text. If the string of text is to contain any spaces, it must be enclosed in double quotes. An <b>ifstring</b> command must use the following format:
@@ -175,6 +187,13 @@ if sword(parent) = field
 </tr><tr>
 <td><b>!containsC</b></td>
 <td>This tests if the first string doesn't contain the second string including case</td>
+</tr>
+<tr>
+<td><b>beginswith</b></td>
+<td>This tests if the first string begins with the second string</td>
+</tr><tr>
+<td><b>!beginswith</b></td>
+<td>This tests if the first string doesn't begin with the second string</td>
 </tr>
 </table>
 </center>
@@ -369,9 +388,9 @@ The following scopes can be used with the <b>select</b> command:
 <tr><td><img src="info.png" alt="Information"></td>
 <td>As only a single parameter can be used with a <b>select</b> command it is more efficient to use the criterion that selects the smallest set of the object when <b>if</b> statements are required to filter the list further. For example, if you wanted a list of all the objects that are being carried by the player that don't have a <b>mass</b> of <b>scenery</b>, the it would be more efficient to use the <b>select</b> command to find the objects that are children of the player and then <b>if</b> statements to check their mass. This is because there will generally be fewer objects in the game that are currently being carried by the player than objects with a <b>mass</b> that isn't set to <b>scenery</b>. If the <b>select</b> command has been used to find all the objects that aren't scenery, the <b>if</b> statement to check if each object is also carried by the player would need to be executed many more times.
 </td></tr></table>
-<h2><a class="section" name="flowcontrol7">The REPEAT and UNTIL Commands</a></h2>
+<h2><a class="section" name="flowcontrol7">The REPEAT, UNTIL and UNTILALL Commands</a></h2>
 
-<P>A <B>repeat</B>... <B>until</B> loop allows you to repeat a section of code until a specified condition is true. The expression or expressions to be tested should follow the <B>until</B> statement, using the same syntax as an <B>if </B>statement. 
+<P>A <B>repeat</B>... <B>until</B> loop allows you to repeat a section of code until a specified condition is true. The expression or expressions to be tested should follow the <B>until</B> statement, using the same syntax as an <B>if </B>statement.
 
 <P>The following is an example of a <B>repeat</B>... <B>until</B> loop:
 
@@ -381,6 +400,14 @@ repeat
   write "DON'T PANIC! "
   set INDEX - 1
 until INDEX = 0
+</pre>
+
+<p>The <b>untilall</b> command works in the same way as <b>until</b> except that when multiple expressions are supplied, the loop only exits when all of the expressions are true &mdash; a logical <b>AND</b>. This is equivalent to the relationship between <b>if</b> and <b>ifall</b>. For example:
+
+<pre>
+repeat
+   set counter + 1
+untilall counter = 10 : status = 1
 </pre>
 
 <table class="infowarn"><tr>
@@ -411,7 +438,7 @@ endloop
 </td>
 </tr></table>
 
-<h2><a class="section" name="flowcontrol8">The WHILE and ENDWHILE Commands</a></h2>
+<h2><a class="section" name="flowcontrol8">The WHILE, WHILEALL and ENDWHILE Commands</a></h2>
 
 <p>As a <b>repeat</b> loop will always happen at least once, if there is any chance that a loop should happen zero times, a <b>while</b> loop must be used. A <b>while</b> loop performs its test first, then executes the code following the expression if it evaluates to <b>true</b>. On reaching an <b>endwhile</b> command it will return to the matching <b>while</b> command and re-evaluate the expression. When the expression eventually evaluates to <b>false</b>, execution will continue from the line after the <b>endwhile</b> command. For example, the following function will output the value of the passed arguments:
 
@@ -424,6 +451,29 @@ while INDEX != @arg
 endwhile
 }
 </pre>
+
+<p>The <b>whileall</b> command works in the same way as <b>while</b> except that when multiple expressions are supplied, the loop continues only if all of the expressions are true &mdash; a logical <b>AND</b>. This is equivalent to the relationship between <b>if</b> and <b>ifall</b>. For example:
+
+<pre>
+whileall counter &lt; 10 : status = 1
+   set counter + 1
+endwhile
+</pre>
+
+<h2><a class="section" name="flowcontrol10">The BREAK Command</a></h2>
+
+<p>The <b>break</b> command is used to immediately exit the current loop. When a <b>break</b> command is executed, execution continues from the line after the end of the loop (<b>endwhile</b>, <b>until</b>, <b>endloop</b>, <b>endselect</b>, <b>enditerate</b>, etc.). For example:
+
+<pre>
+while counter &lt; 100
+   if counter = 50
+      break
+   endif
+   set counter + 1
+endwhile
+</pre>
+
+<p>In the above code, if <b>counter</b> reaches 50, the <b>break</b> command will exit the <b>while</b> loop immediately and execution will continue from after the <b>endwhile</b> command.
 
 <h2><a class="section" name="flowcontrol9">The RETURN Command</a></h2>
 

--- a/guide/http.html
+++ b/guide/http.html
@@ -196,7 +196,7 @@ button "Read Map"
 
 <p>It is possible to use a second HTML control, such as a list box, in conjunction with a submit button to create verb-noun commands. See the <b>control</b> command below for more information.
  
-<h2><a class="section" name="http7">The HYPERLINK Command</a></h2>
+<h2><a class="section" name="http7">The HYPERLINK and HYPERLINKNE Commands</a></h2>
 
 <p>The command <b>hyperlink</b> is a simple method of creating a hyperlink that issues a command for the player. It can accept either two or three parameters.
 The first is the visible text to be displayed. The second parameter is the command to be issued when the link is clicked. The third, optional, parameter is the name of a CSS class that should be applied to the link. Below are some sample hyperlinks:
@@ -211,8 +211,10 @@ hyperlink "Where am I?" look big
 
 <table class="infowarn"><tr>
 <td><img src="warning.png"></td>
-<td>When using the <b>hyperlink</b> command, any spaces in the third parameter (the command to be executed), must be replaced with plus signs. This is due to the fact that the command is pasted as part of the URL sent to the web browser, and spaces are not valid in a URL.</td>
+<td>When using the <b>hyperlink</b> command, any spaces in the second parameter (the command to be executed), must be replaced with plus signs. This is due to the fact that the command is passed as part of the URL sent to the web browser, and spaces are not valid in a URL.</td>
 </tr></table>
+
+<p>The <b>hyperlinkNE</b> command works in the same way as the <b>hyperlink</b> command except that it does not URL-encode the command parameter. This can be useful when the command string has already been encoded or when constructing complex URLs manually.
 
 <p>When manually creating special-purpose hyperlinks, the <b>{+name}</b> macro is very useful. For more information, see the chapter on <a href="screendisplay.html">Screen Display</a>.
 
@@ -269,7 +271,26 @@ parameter destination SOME_VARIABLE
 
 <p>When this form is submitted, the <b>cgijacl</b> interpreter will look for the parameter <b>destination</b>, as it has been defined using a <b>parameter</b> statement. This parameter will contain the internal number of the object that was selected and this number will be copied into the location specified by the <b>parameter</b> statement. In this case, a variable called <b>SOME_VARIABLE</b>. For more information see the section on <a href="definitions.html#definitions10">parameters</a>.
 
-<h2><a class="section" name="http10">The IMAGE Command</a></h2>
+<h2><a class="section" name="http10">The GETENV Command</a></h2>
+
+<p>The <b>getenv</b> command is used to retrieve the value of an environment variable and store it in a JACL string variable. This is primarily useful for reading CGI environment variables such as HTTP headers and request parameters. A <b>getenv</b> command must be of the following format:
+
+<pre>
+<b>getenv</b> <i>StringVariable EnvironmentVariableName</i>
+</pre>
+
+<p>The first parameter is the JACL string variable to store the value in. The second parameter is the name of the environment variable to read. If the specified environment variable does not exist, the string variable will be set to an empty string. Below is an example of its use:
+
+<pre>
+string current_user
+
+{+header
+getenv current_user "REMOTE_USER"
+write "&lt;p&gt;Welcome, " current_user "!&lt;/p&gt;"
+}
+</pre>
+
+<h2><a class="section" name="http11">The IMAGE Command</a></h2>
 
 <p>The <b>image</b> command is used to display an image &mdash; no surprise there. It requires three parameters using the following syntax:
 	
@@ -285,7 +306,7 @@ image "/images/view.jpg" left "[View from the balcony]"
 
 <p>This command displays the image <b>/images/view.jpg</b> aligned to the left. If the picture is not found, or is displayed in a text-only browser such as Lynx, the text <b>[View from the balcony]</b> will be displayed instead. This is also the text that will be displayed by most graphical browsers when the cursor is held over the image.
 
-<h2><a class="section" name="http11">The Media File</a></h2>
+<h2><a class="section" name="http12">The Media File</a></h2>
 
 <p>When played with the <b>cgijacl</b> interpreter, each game will require a corresponding <b>.media</b> file in order to serve multi-media content such as images. This file must have the same name as the game, with a <b>.media</b> suffix in place of the <b>.jacl</b> suffix. For example, the game <b>grail.jacl</b> has a matching media file called <b>grail.media</b>. As this game only has one image, its media file only has one line:
 

--- a/guide/index.html
+++ b/guide/index.html
@@ -69,7 +69,7 @@
 		<li><a href="screendisplay.html#screendisplay8">Printing the Value of String Constants</a>
 	</ol>
 	<li><a href="screendisplay.html#screendisplay9">The PRINT Command</a>
-	<li><a href="screendisplay.html#screendisplay10">The LOOK Command</a>
+	<li><a href="screendisplay.html#screendisplay10">The OUTPUT Command</a>
 	<li><a href="screendisplay.html#screendisplay11">The LOOK Command</a>
 	<li><a href="screendisplay.html#screendisplay12">The MORE Command</a>
 </ol>
@@ -96,11 +96,12 @@
 	<li><a href="http.html#http4">The Player's Commands</a>
 	<li><a href="http.html#http5">Ajax Requests</a>
 	<li><a href="http.html#http6">The BUTTON Command</a>
-	<li><a href="http.html#http7">The HYPERLINK Command</a>
+	<li><a href="http.html#http7">The HYPERLINK and HYPERLINKNE Commands</a>
 	<li><a href="http.html#http8">The CONTROL Command</a>
 	<li><a href="http.html#http9">The OPTION Command</a>
-	<li><a href="http.html#http10">The IMAGE Command</a>
-	<li><a href="http.html#http11">The Media File</a>
+	<li><a href="http.html#http10">The GETENV Command</a>
+	<li><a href="http.html#http11">The IMAGE Command</a>
+	<li><a href="http.html#http12">The Media File</a>
 </ol>
 
 <li><a class="chapter" href="webinterface.html#webinterface0">GUI Web Interface</a>
@@ -117,8 +118,9 @@
 	<li><a href="flowcontrol.html#flowcontrol4">The ELSE Command</a>
 	<li><a href="flowcontrol.html#flowcontrol5">The LOOP and ENDLOOP Commands</a>
 	<li><a href="flowcontrol.html#flowcontrol6">The SELECT and ENDSELECT Commands</a>
-	<li><a href="flowcontrol.html#flowcontrol7">The REPEAT and UNTIL Commands</a>
-	<li><a href="flowcontrol.html#flowcontrol8">The WHILE and ENDWHILE Commands</a>
+	<li><a href="flowcontrol.html#flowcontrol7">The REPEAT, UNTIL and UNTILALL Commands</a>
+	<li><a href="flowcontrol.html#flowcontrol8">The WHILE, WHILEALL and ENDWHILE Commands</a>
+	<li><a href="flowcontrol.html#flowcontrol10">The BREAK Command</a>
 	<li><a href="flowcontrol.html#flowcontrol9">The RETURN Command</a>
 </ol>
 
@@ -155,6 +157,7 @@
 	<li><a href="special.html#special8">The GETSTRING Command</a>
 	<li><a href="special.html#special9">The GETYESORNO Command</a>
 	<li><a href="special.html#special10">The SAVEGAME and RESTOREGAME Commands</a>
+	<li><a href="special.html#special14">The FLUSH Command</a>
 	<li><a href="special.html#special12">The TERMINATE Command</a>
 	<li><a href="special.html#special13">The UNDOMOVE Command</a>
 
@@ -235,6 +238,7 @@
 	<li><a href="csv.html#csv1">The ITERATE and ENDITERATE Commands</a>
 	<li><a href="csv.html#csv2">The UPDATE, ENDUPDATE and INSERT Commands</a>
 	<li><a href="csv.html#csv3">The APPEND Command</a>
+	<li><a href="csv.html#csv4">The APPEND_FC, APPEND_NT and APPEND_LC Commands</a>
 </ol>
 
 <li><a href="attributessummary.html#attributesummary0">Appendix A: JACL Attributes</a>

--- a/guide/screendisplay.html
+++ b/guide/screendisplay.html
@@ -280,7 +280,23 @@ print:
 }
 
 </pre>
-<h2><a class="section" name="screendisplay10">The LOOK Command</a></h2>
+<h2><a class="section" name="screendisplay10">The OUTPUT Command</a></h2>
+
+<p>The <b>output</b> command reads the entire contents of a file and writes it to the game's output stream. The file is read from the game's data directory. A single parameter specifying the filename is required:
+
+<pre>
+<b>output</b> <i>FileName</i>
+</pre>
+
+<p>For example, the following command will read and display the contents of a file called <b>welcome_text</b> from the data directory:
+
+<pre>
+output welcome_text
+</pre>
+
+<p>This command is useful for including large blocks of pre-written text that would be unwieldy to embed directly in the game source code.
+
+<h2><a class="section" name="screendisplay11">The LOOK Command</a></h2>
 
 <P>The <b>look</b> command will print the long description of the current location and any visible objects that are in the current location. A <b>look</b> command is executed implicitly by the JACL interpreter whenever a description of the player's current location is required. This is at times such as when then player moves into a location for the first time or restores a saved game.
 
@@ -304,7 +320,7 @@ write here{The} ^
 
 <P>It is a convention to have a <B>look</B> command at the end of the <B>+intro </B>function so the player can see where they are and what objects are nearby when the game begins.
 
-<h2><a class="section" name="screendisplay11">The MORE Command</a></h2>
+<h2><a class="section" name="screendisplay12">The MORE Command</a></h2>
 
 <p>The <b>more</b> command will print a message and then wait for the player to press a key before continuing. The message to print is passed as the only parameter of a <b>more</b> command. If no message is provided, the message <b>[MORE]</b> is used as a default. Below is an example of using the <b>more</b> command with a custom message:
 

--- a/guide/special.html
+++ b/guide/special.html
@@ -216,6 +216,16 @@ if save_timer = 0
 endif
 </pre>
 
+<h2><a class="section" name="special14">The FLUSH Command</a></h2>
+
+<p>The <b>flush</b> command forces the display buffer to be flushed to the screen. This command takes no parameters:
+
+<pre>
+flush
+</pre>
+
+<p>This command is platform-specific. On the Nintendo DS interpreter it forces the display to update immediately. On Glk and CGI interpreters this command has no effect and is safely ignored. It is included primarily to allow games that target the Nintendo DS to control when output appears on the screen.
+
 <h2><a class="section" name="special12">The TERMINATE Command</a></h2> 
 
 <p>The <b>terminate</b> command will directly initiate the termination of the JACL interpreter.


### PR DESCRIPTION
The guide was missing documentation for several commands that are implemented in the interpreter. This adds documentation for:

- Flow control: endall, whileall, untilall, break
- String comparison: beginswith, !beginswith operators for ifstring
- CSV operations: append_fc, append_nt, append_lc
- Screen display: output command
- HTTP/CGI: hyperlinkNE variant, getenv command
- Special commands: flush

Also fixes the index.html table of contents to match the actual section anchors and removes a duplicate LOOK entry.