### PR TITLE
Fix all compiler warnings in project source files

### DIFF
--- a/src/bjorb.c
+++ b/src/bjorb.c
@@ -106,14 +106,14 @@ str_short (char *f, unsigned int v)
 }
 
 static void
-write_id (FILE * f, unsigned char *s)
+write_id (FILE * f, const char *s)
 /*
  * write_id writes a string to a file as a blorb ID string (4 bytes, space
- * padded) 
+ * padded)
  */
 {
   int i;
-  unsigned char sp = ' ';
+  char sp = ' ';
 
   for (i = 0; i < strlen (s); i++)
     fwrite (&s[i], 1, 1, f);
@@ -122,11 +122,11 @@ write_id (FILE * f, unsigned char *s)
 }
 
 static void
-str_id (char *f, unsigned char *s)
+str_id (char *f, const char *s)
 // str_id writes a blorb identifier to a string
 {
   int i;
-  unsigned char sp = ' ';
+  char sp = ' ';
 
   for (i = 0; i < strlen (s); i++)
     f[i] = s[i];
@@ -284,7 +284,7 @@ BuildIndex (FILE * f)
   // space
   Blorb[0]->Length = (12 * n) + 4;
   Blorb[0]->Data = (char *) my_malloc (Blorb[0]->Length);
-  Index = (long *) my_malloc (n * sizeof (unsigned long));
+  Index = (unsigned long *) my_malloc (n * sizeof (unsigned long));
   // The first thing in the data chunk is the number of entries
   str_long (Blorb[0]->Data, n);
   // Now, scroll through the chunks, noting each one in the index chunk

--- a/src/findroute.c
+++ b/src/findroute.c
@@ -52,27 +52,6 @@ qIsEmpty(Queue *q)
 }
 
 static void
-qDebug(Queue *q)
-{
-	printf("Queue:");
-
-	if (q->head == NULL)
-	{
-		printf(" empty");
-	}
-	else
-	{
-		QueueNode *node;
-		for (node = q->head;node != NULL;node = node->next)
-		{
-			printf(" %d (%d)", node->val, node->val2);
-		}
-	}
-
-	putchar('\n');
-}
-
-static void
 qAppend(Queue *q, int val, int val2)
 {
 	QueueNode *node = (QueueNode*) malloc(sizeof(QueueNode));
@@ -107,44 +86,6 @@ qPop(Queue *q, int *val, int *val2)
 	{
 		q->head = q->head->next;
 	}
-}
-
-static void
-qTest(void)
-{
-	int val, val2;
-	Queue q;
-
-	qInit(&q);
-	qDebug(&q);
-
-	printf("\nAdd 3, 0\n");
-	qAppend(&q, 3, 0);
-	qDebug(&q);
-
-	printf("\nAdd 4, 2\n");
-	qAppend(&q, 4, 2);
-	qDebug(&q);
-
-	printf("\nAdd 5, 1\n");
-	qAppend(&q, 5, 1);
-	qDebug(&q);
-
-	qPop(&q, &val, &val2);
-	printf("\nPop %d, %d\n", val, val2);
-	qDebug(&q);
-
-	qPop(&q, &val, &val2);
-	printf("\nPop %d, %d\n", val, val2);
-	qDebug(&q);
-
-	printf("\nAdd 6, 3\n");
-	qAppend(&q, 6, 3);
-	qDebug(&q);
-
-	printf("\nDelete all\n");
-	qDelete(&q);
-	qDebug(&q);
 }
 
 /**************************************/
@@ -195,26 +136,6 @@ setDelete(Set *set)
 	}
 }
 
-static void
-setDebug(Set *set)
-{
-	int n;
-
-	printf("Set:");
-
-	for (n = 0;n < SET_HASHSIZE;n++)
-	{
-		SetNode *node;
-
-		for (node = set->node[n];node != NULL;node = node->next)
-		{
-			printf(" %d", node->val);
-		}
-	}
-
-	putchar('\n');
-}
-
 static int
 setHash(int val)
 {
@@ -254,38 +175,6 @@ setContains(Set *set, int val)
 	}
 
 	return 0;
-}
-
-static void setTest(void)
-{
-	Set s;
-
-	setInit(&s);
-	setDebug(&s);
-
-	printf("\nAdd 34\n");
-	setAdd(&s, 34);
-	setDebug(&s);
-
-	printf("\nAdd 56\n");
-	setAdd(&s, 56);
-	setDebug(&s);
-
-	printf("\nAdd 34 again\n");
-	setAdd(&s, 34);
-	setDebug(&s);
-
-	printf("\nAdd %d\n", 34 + SET_HASHSIZE);
-	setAdd(&s, 34 + SET_HASHSIZE);
-	setDebug(&s);
-
-	printf("\nAdd 78\n");
-	setAdd(&s, 78);
-	setDebug(&s);
-
-	printf("\nDelete all\n");
-	setDelete(&s);
-	setDebug(&s);
 }
 
 /**************************************/

--- a/src/glk_saver.c
+++ b/src/glk_saver.c
@@ -12,7 +12,6 @@
 static void write_integer(strid_t stream, int x);
 static void write_long(strid_t stream, long x);
 static int  read_integer(strid_t stream);
-static long read_long(strid_t stream);
 
 int
 save_game(frefid_t saveref)
@@ -231,13 +230,4 @@ write_long(strid_t stream, long x)
     glk_put_char_stream(stream, c);
 }
 
-long 
-read_long(strid_t stream)
-{
-    long a, b, c, d;
-    a = (long) glk_get_char_stream(stream);
-    b = (long) glk_get_char_stream(stream);
-    c = (long) glk_get_char_stream(stream);
-    d = (long) glk_get_char_stream(stream);
-    return a | (b << 8) | (c << 16) | (d << 24);
-}
+

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -75,8 +75,10 @@ static int            read_fd;
 static struct flock    write_lck;
 static int            write_fd;
 
+#ifndef GLK
 static char *url_encode(const char *str);
 static char to_hex(char code);
+#endif
 
 static const char * const location_attributes[] = {
  "VISITED ", "DARK ", "ON_WATER ", "UNDER_WATER ", "WITHOUT_AIR ", "OUTDOORS ",
@@ -117,7 +119,9 @@ static struct stack_type        backup[STACK_SIZE];
 static struct proxy_type        proxy_backup[STACK_SIZE];
 
 static struct function_type *resolved_function = NULL;
+#if defined(GLK) || defined(__NDS__)
 static struct string_type *resolved_string = NULL;
+#endif
 
 static struct string_type *new_string = NULL;
 struct string_type *current_cstring = NULL;
@@ -144,7 +148,9 @@ static int                        criterion_type = 0;
 static int                        criterion_negate = FALSE;
 static int                         current_level;
 static int                         execution_level;
+#if defined(GLK) || defined(__NDS__)
 static int                         *ask_integer;
+#endif
 static int                        new_x;
 static int                        new_y;
 
@@ -313,7 +319,6 @@ execute(const char *funcname)
     /* THESE ARE USED AS FILE POINTER OFFSETS TO RETURN TO FIXED
      * POINTS IN THE GAME FILE */
 #ifdef GLK
-    int                result;
     glsi32            before_command = 0;
 #else
     long            before_command = 0;
@@ -368,7 +373,7 @@ execute(const char *funcname)
 #ifdef GLK
     glk_stream_set_position(game_stream, executing_function->position, seekmode_Start);
     before_command = executing_function->position;
-    result = glk_get_bin_line_stream(game_stream, text_buffer, (glui32) 1024);
+    glk_get_bin_line_stream(game_stream, text_buffer, (glui32) 1024);
 #else
     fseek(file, executing_function->position, SEEK_SET);
     before_command = executing_function->position;
@@ -1404,7 +1409,7 @@ execute(const char *funcname)
                     }
 
                     if (!strcmp(word[0], "hyperlink")) {
-                            free (encoded); 
+                            free ((void *)encoded);
                     }
 
                     write_text(string_buffer);
@@ -3530,6 +3535,7 @@ select_next()
     return (FALSE);
 }
 
+#ifndef GLK
 /* Converts an integer value to its hex character*/
 char to_hex(char code) {
     static char hex[] = "0123456789abcdef";
@@ -3542,9 +3548,9 @@ char *url_encode(const char *str) {
     const char *pstr = str;
     char *buf = malloc(strlen(str) * 3 + 1), *pbuf = buf;
     while (*pstr) {
-        if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~') 
+        if (isalnum(*pstr) || *pstr == '-' || *pstr == '_' || *pstr == '.' || *pstr == '~')
             *pbuf++ = *pstr;
-        else if (*pstr == ' ') 
+        else if (*pstr == ' ')
             *pbuf++ = '+';
         else {
             *pbuf++ = '%'; *pbuf++ = to_hex(*pstr >> 4); *pbuf++ = to_hex(*pstr & 15);
@@ -3554,3 +3560,4 @@ char *url_encode(const char *str) {
     *pbuf = '\0';
     return buf;
 }
+#endif

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -112,7 +112,7 @@ int             player = 0;
 static int      noun3_backup;
 static int      player_backup = 0;
 
-static int      variable_contents;
+
 int             oec;
 int            *object_element_address,
 			   *object_backup_address;
@@ -892,8 +892,6 @@ newline()
 void
 more(const char* message)
 {
-	int character;
-
 	jacl_set_window(inputwin);
 
 	if (inputwin == promptwin) {
@@ -905,7 +903,7 @@ more(const char* message)
 	write_text(message);
 	glk_set_style(style_Normal);
 
-	character = get_key();
+	get_key();
 
 	if (inputwin == mainwin) newline();
 }

--- a/src/loader.c
+++ b/src/loader.c
@@ -60,18 +60,12 @@ read_gamefile()
     int            is_static = FALSE;
 
     long           start_of_file = 0;
-#ifdef GLK
-    glui32         current_file_position;
-#else
-    long         current_file_position;
-#endif
 
     long           bit_mask;
 
     struct filter_type *current_filter = NULL;
     struct filter_type *new_filter = NULL;
     struct attribute_type *current_attribute = NULL;
-    struct attribute_type *new_attribute = NULL;
     struct cinteger_type *resolved_cinteger = NULL;
     struct synonym_type *current_synonym = NULL;
     struct synonym_type *new_synonym = NULL;
@@ -994,10 +988,8 @@ read_gamefile()
         }
 
 #ifdef GLK
-        current_file_position = glk_stream_get_position(game_stream);
         result = glk_get_bin_line_stream(game_stream, text_buffer, (glui32) 1024);
 #else
-        current_file_position = ftell(file);
         fgets(text_buffer, 1024, file);
 #endif
         line++;
@@ -1407,7 +1399,6 @@ void
 create_attribute(const char *name) 
 {
     struct attribute_type *new_attribute = NULL;
-    int index;
 
   if ((new_attribute = (struct attribute_type *)
      malloc(sizeof(struct attribute_type))) == NULL) {

--- a/src/logging.c
+++ b/src/logging.c
@@ -106,6 +106,8 @@ log_message(const char *message, int console)
 	char 			consoleMessage[256];
 	char 			temp_buffer[256];
 
+	time(&tnow);
+
 	/* MAKE THE LOG MESSAGE WITH GAME PREFIX */
 	sprintf(temp_buffer, "%s - %s - %s\n", strip_return(ctime(&tnow)), prefix, message);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -30,7 +30,9 @@ int								max_size[4];
  * noun2 EXCEPTIONS	: 3
  */
 
+#if defined(GLK) || defined(__NDS__)
 static int             			selection;
+#endif
 
 static int				        matches = 0;
 static int            			highest_confidence = 0;
@@ -40,7 +42,9 @@ static int             			backup_pointer = 0;
 static int						everything = 0;
 
 static int             			confidence[MAX_OBJECTS];
+#if defined(GLK) || defined(__NDS__)
 static int						possible_objects[MAX_OBJECTS];
+#endif
 
 int								it;
 int								them[MAX_OBJECTS];
@@ -1626,13 +1630,13 @@ noun_resolve(struct word_type *scope_word, int finding_from, int noun_number)
 	/* AN AMBIGUOUS REFERENCE WAS MADE. ATTEMPT TO CALL ALL THE disambiguate
 	 * FUNCTIONS TO SEE IF ANY OF THE OBJECT WANTS TO TAKE PREFERENCE IN
 	 * THIS CIRCUMSTANCE */
+	/*
 	int situation = noun_number;
 
 	if (finding_from) {
 		situation += 4;
 	}
 
-	/* 
 	for (index = 1; index <= objects; index++) {
 		if (confidence[index] != FALSE) {
 			strcpy(function_name, "disambiguate");

--- a/src/saver.c
+++ b/src/saver.c
@@ -11,7 +11,6 @@
 static void write_integer(FILE *file, int x);
 static void write_long(FILE *file, long x);
 static int  read_integer(FILE *file);
-static long read_long(FILE *file);
 
 int
 save_game(const char *filename)
@@ -213,13 +212,4 @@ write_long(FILE *file, long x)
     putc(c, file);
 }
 
-long 
-read_long(FILE *file)
-{
-    long a, b, c, d;
-    a = (long) getc(file);
-    b = (long) getc(file);
-    c = (long) getc(file);
-    d = (long) getc(file);
-    return a | (b << 8) | (c << 16) | (d << 24);
-}
+


### PR DESCRIPTION
## Summary
- Remove unused variables, functions, and test code across 9 source files
- Wrap GLK/NDS-only declarations with preprocessor guards so they don't warn in CGI builds
- Fix uninitialized `tnow` in `logging.c` (was passing garbage to `ctime()` — this was a bug, not just a warning)
- Fix pointer sign mismatches in `bjorb.c` by using `const char *` instead of `unsigned char *`
- Fix const qualifier warning on `free()` call for URL-encoded strings

Warnings from third-party libraries (glkterm, CheapGlk, cgihtml) are left untouched.

## Test plan
- [x] `make clean && make install` completes with zero warnings from project source files
- [ ] Verify interpreter, loader, and parser still function correctly with a test game

🤖 Generated with [Claude Code](https://claude.com/claude-code)