### PR TITLE
Modernize web libraries: replace jQuery with fetch API

### DIFF
--- a/projects/ajax.jacl
+++ b/projects/ajax.jacl
@@ -2,12 +2,11 @@
 {+header
 set linebreaks = false
 print:
-	<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">^
+	<!DOCTYPE html>
 	<html><head>^
 	<title>Test of Ajax fetch</title>^
-	<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">^
-	<script src="/include/jquery-3.6.0.min.js"></script>^
-	<script language="JavaScript">^
+	<meta charset="UTF-8">^
+	<script>^
 .
 #include "ajax.library"
 print:
@@ -25,22 +24,25 @@ print:
 	<button id="option2"><img src="/images/tiles/red_chest.png"></button>^
 	<form name="command" id="commandForm">
 .
-		prompt	
+		prompt
 print:
 	</form>
-	<script language="JavaScript">^
-		$('#option1').click( { async: true, command: "greenchest", element: "#screen", replace: "false" }, ajaxRequest);^
-		$('#option2').click( { async: true, command: "redchest", element: "#screen", replace: "false" }, ajaxRequest);^
-		$('#commandForm').submit ( submitForm );^
-
-		function submitForm() {
-			ajaxForm({ 
+	<script>^
+		document.getElementById('option1').addEventListener('click', function() {^
+			ajaxRequest({ data: { command: "greenchest", element: "#screen", replace: "false" } });^
+		});^
+		document.getElementById('option2').addEventListener('click', function() {^
+			ajaxRequest({ data: { command: "redchest", element: "#screen", replace: "false" } });^
+		});^
+		document.getElementById('commandForm').addEventListener('submit', function(e) {^
+			e.preventDefault();^
+			ajaxForm({
 				command: document.getElementById('JACLCommandPrompt').value,
 				replace: false,
 				element: "#screen"
-			});
-			return false;
-		}
+			});^
+			return false;^
+		});^
 	</script>^
 	</body>
 </html>
@@ -61,7 +63,7 @@ write "You clicked on the red chest.<br>"
 
 {+intro
 print:
-<p>Test of jQuery.ajax.</p>
+<p>Test of fetch API.</p>
 .
 }
 

--- a/projects/include/ajax.library
+++ b/projects/include/ajax.library
@@ -1,58 +1,55 @@
 write "function ajaxForm(details) {^"
-write "var url_string = ~" $url "?ajax=true&command=~ + details.command + "~"
+write "var url_string = ~" $url "?ajax=true&command=~ + encodeURIComponent(details.command) + "~"
 if remote_user = false
 	write "+ ~&user_id=" $user_id "~;^"
 else
 	write ";^"
 endif
 print:
-	$.ajax({
-		url: url_string,^
-		success: function (data) {^
+	fetch(url_string)
+		.then(function(response) { return response.text(); })
+		.then(function(data) {^
 .
 ifexecute "+local_success"
 	# RESULT HANDLED BY LOCAL APPLICATION
 else
 print:
 	# DEFAULT ACTION
-			if (details.replace == true) {^
-				console.log(details);
-				$(details.element).html(data);^
+			if (details.replace === true) {^
+				document.querySelector(details.element).innerHTML = data;^
 			} else {^
-				console.log(details);
-				$(details.element).append(data);^
+				document.querySelector(details.element).innerHTML += data;^
 			}^
 .
 endif
 print:
-		}^
-	});^
+		});^
 }^
 .
 write "function ajaxRequest(event) {^"
 write "var url_string = ~" $url "?ajax=true&command=~ + "
-write "event.data.command"
+write "encodeURIComponent(event.data.command)"
 if remote_user = false
 	write "+ ~&user_id=" $user_id "~;^"
 else
 	write ";^"
 endif
-write "$.ajax({^url: url_string,^"
-write "		success: function (data) {^"
+write "fetch(url_string)^"
+write "		.then(function(response) { return response.text(); })^"
+write "		.then(function(data) {^"
 ifexecute "+local_success"
 	# RESULT HANDLED BY LOCAL APPLICATION
 else
 	# DEFAULT ACTION
 	print:
-			if (event.data.replace == true) {^
-				$(event.data.element).html(data);^
+			if (event.data.replace === true) {^
+				document.querySelector(event.data.element).innerHTML = data;^
 			} else {^
-				$(event.data.element).append(data);^
+				document.querySelector(event.data.element).innerHTML += data;^
 			}^
    .
 endif
 print:
-		}^
-	});^
+		});^
 }^
 .

--- a/projects/include/dangarstu.library
+++ b/projects/include/dangarstu.library
@@ -18,41 +18,25 @@ grammar standard >standard
 {+header
 set linebreaks = false
 print:
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"^
-  "http://www.w3.org/TR/html4/loose.dtd">^
-   <html xmlns="http://www.w3.org/1999/xhtml" dir="ltr" lang="en-US"
-         xmlns:fb="https://www.facebook.com/2008/fbml">
+<!DOCTYPE html>
+   <html dir="ltr" lang="en-US">
    <head>
-   <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
-   <meta name="description" content="Music website for DangarStu." />
-   <meta name="keywords" content="DangarStu,Music,Stuart Allen" />
-   <meta name="author" content="Stuart Allen" />
-   <meta property="og:description" content="DangarStu music website." />
-   <meta property="og:title" content="DangarStu" />
-   <meta property="og:type" content="musician" />
-   <meta property="og:url" content="http://dangarstu.com" />
-   <meta property="og:image" content="http://dangarstu.com/images/InStudioSmall.jpg" />
-   <meta property="og:site_name" content="DangarStu" />
-   <meta property="fb:admins" content="725658316" />
+   <meta charset="UTF-8">
+   <meta name="description" content="Music website for DangarStu.">
+   <meta name="keywords" content="DangarStu,Music,Stuart Allen">
+   <meta name="author" content="Stuart Allen">
+   <meta property="og:description" content="DangarStu music website.">
+   <meta property="og:title" content="DangarStu">
+   <meta property="og:type" content="musician">
+   <meta property="og:url" content="http://dangarstu.com">
+   <meta property="og:image" content="http://dangarstu.com/images/InStudioSmall.jpg">
+   <meta property="og:site_name" content="DangarStu">
 .
 write "<title>" game_title "</title>"
 execute "+styles"
 print:
-   <style type='text/css'>a.soundcloud-badge:hover {background-position: bottom left !important;} *html a.soundcloud-badge {background-image: none !importan
-t; filter: progid:DXImageTransform.Microsoft.AlphaImageLoader(src='(http://a1.sndcdn.com/images/badges/fmonsc/horizontal/white.png?04ad178)', sizingMetho
-d='crop') !important;}</style>
-   <script src="/include/jquery-1.7.min.js"></script>
    <link rel="icon" href="/images/favicon.ico" type="image/x-icon">
    </head><body>^
-   <div id="fb-root"></div>
-   <script>(function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) return;
-      js = d.createElement(s); js.id = id;
-      js.src = "//connect.facebook.net/en_US/all.js#xfbml=1";
-      fjs.parentNode.insertBefore(js, fjs); }
-      (document, 'script', 'facebook-jssdk'));                                                  
-   </script>                                                                                    
    <div id="header">
 .
 ifstring title_image = "none"

--- a/projects/include/french_webinterface.library
+++ b/projects/include/french_webinterface.library
@@ -21,16 +21,14 @@ write "L'interface passe en mode standard.^"
 {+header
 set linebreaks = false
 print:
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"^
-  "http://www.w3.org/TR/html4/loose.dtd">^
+<!DOCTYPE html>
 .
 write "<html><head>"
-write "<meta HTTP-EQUIV=~Content-Type~ CONTENT=~text/html; charset=UTF-8~>"
+write "<meta charset=~UTF-8~>"
 write "<title>" game_title "</title>"
 execute "+styles"
 print:
-   <script language=~JavaScript~>^
-   <!--^
+   <script>^
    function changeInterface() {^
       document.JACLInterfaceForm.submit(); }^
    function putFocus(formInst, elementInst) {^
@@ -39,23 +37,21 @@ print:
 .
 if gui_mode = STANDARD : gui_mode = MOBILE
    print:
-      function userCommand() { ^
-      var xhReq = createXMLHttpRequest();^
-      if(xhReq == null) { return true; }^
+      function userCommand() {^
       var user_id = document.JACLGameForm.user_id.value;^
       var command = document.JACLGameForm.command.value;^
-      xhReq.open("GET",
    .
-   write "~" $url
+   write "var url_string = ~" $url
    print:
-      ?user_id="+user_id+"&command="+command+"&ajax=true", false);^
-      xhReq.send(null);^
-      var serverResponse = xhReq.responseText;^
-      var maintext = document.getElementById("maintext");^
-      maintext.innerHTML += "<br><b>&gt;" + command + "</b><br>" + serverResponse;^
-      var main = document.getElementById("main");^
-      main.scrollTop = main.scrollHeight;^
-      document.JACLGameForm.command.value = "";^
+?user_id="+user_id+"&command="+encodeURIComponent(command)+"&ajax=true";^
+      fetch(url_string)^
+         .then(function(response) { return response.text(); })^
+         .then(function(data) {^
+            var maintext = document.getElementById("maintext");^
+            maintext.innerHTML += "<br><b>&gt;" + command + "</b><br>" + data;^
+            var main = document.getElementById("main");^
+            main.scrollTop = main.scrollHeight;^
+            document.JACLGameForm.command.value = "";^
 .
 if gui_mode = MOBILE
    write "putFocus(0, 0);^"
@@ -63,15 +59,10 @@ else
    write "putFocus(1, 0);^"
 endif
 print:
+      });^
       return false; }^
-      function createXMLHttpRequest() {^
-      try { return new XMLHttpRequest(); } catch(e) {}^
-      try { return new ActiveXObject("Msxml2.XMLHTTP"); } catch (e) {}^
-      alert("XMLHttpRequest not supported");^
-      return null; }^
    .
 endif
-write "-->"
 write "</script>^"
 write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
 write "</head>^"
@@ -94,19 +85,19 @@ if gui_mode != MOBILE
    write "Standard<input type=~radio~ name=~interface~ value=~1~"
    if gui_mode = STANDARD
       write " checked onclick=~return changeInterface();~>"
-   else 
+   else
       write " onclick=~return changeInterface();~>"
    endif
    write " GUI<input type=~radio~ name=~interface~ value=~2~"
    if gui_mode = GUI
       write " checked onclick=~return changeInterface();~>"
-   else 
+   else
       write " onclick=~return changeInterface();~>"
    endif
    write " Mobile<input type=~radio~ name=~interface~ value=~3~"
    if gui_mode = MOBILE
       write " checked onclick=~return changeInterface();~>"
-   else 
+   else
       write " onclick=~return changeInterface();~>"
    endif
    hidden
@@ -249,7 +240,7 @@ if gui_mode = GUI
       write "<img src=~/images/compass/southeast.png~>"
    endif
    write "</div>^"
-endif   
+endif
 write "</div>"
 write "</form></div>^"
 write "</body></html>^"

--- a/projects/include/webapp.library
+++ b/projects/include/webapp.library
@@ -36,7 +36,6 @@ print:
 write "<title>" game_title "</title>"
 execute "+styles"
 call "+user_styles"
-write "<script src=~/include/jquery-3.6.0.min.js~></script>"
 
 ifstring favicon_image = "none"
 	write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
@@ -44,7 +43,7 @@ else
 	write "<link rel=~icon~ href=~" favicon_image "~ type=~image/x-icon~>"
 endif
 print:
-   <script language=~JavaScript~>^
+   <script>^
 	if (window.matchMedia("(max-width: 767px)").matches) {
 .
 		if WEBAPP_device != WEBAPP_mobile

--- a/projects/include/webinterface.library
+++ b/projects/include/webinterface.library
@@ -5,33 +5,32 @@ string current_image "none"
 {+header
 set linebreaks = false
 print:
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"^
-  "http://www.w3.org/TR/html4/loose.dtd">^
+<!DOCTYPE html>
 <html><head>
-<link href="http://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" type="text/css">
-<meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<link href="https://fonts.googleapis.com/css?family=Merriweather" rel="stylesheet" type="text/css">
+<meta charset="UTF-8">
 .
 write "<title>" game_title "</title>"
 execute "+styles"
 print:
-   <script src="/include/jquery-3.6.0.min.js"></script>
-   <script language="JavaScript">^
+   <script>^
 
    function KeyPressed() {^
-      if ($("#JACLCommandPrompt").val() == "") { 
-         main.scrollTop = main.scrollHeight; 
-      } 
+      if (document.getElementById('JACLCommandPrompt').value === '') {
+         var main = document.getElementById('main');
+         main.scrollTop = main.scrollHeight;
+      }
    }^
 
    function changeInterface() {^
-      document.JACLInterfaceForm.submit(); 
+      document.JACLInterfaceForm.submit();
    }^
 .
 #include "ajax.library"
 write "</script>^"
 write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
 write "</head>^"
-write "<body onLoad=~$('#JACLCommandPrompt').focus();~>^"
+write "<body onLoad=~document.getElementById('JACLCommandPrompt').focus();~>^"
 write "<div id=~header~>"
 ifstring title_image = "none"
   write "<h1 name=~title~>" game_title "</h1>"
@@ -75,7 +74,8 @@ print:
    </div>
    </form></div>^
    <script>
-          function submitForm() {^
+          function submitForm(e) {^
+               e.preventDefault();^
                ajaxForm({^
                     command: document.getElementById('JACLCommandPrompt').value,^
                     replace: false,^
@@ -83,7 +83,7 @@ print:
                });^
                return false;^
           }^
-          $('#commandForm').submit ( submitForm );^
+          document.getElementById('commandForm').addEventListener('submit', submitForm);^
    </script>^
    </body></html>^
 .
@@ -93,30 +93,31 @@ set linebreaks = true
 {+local_success
 print:
       var maintext = document.getElementById("maintext");^
-      $('#maintext').find('audio').remove();^
-      $('#maintext').find('script').remove();^
+      maintext.querySelectorAll('audio').forEach(function(el) { el.remove(); });^
+      maintext.querySelectorAll('script').forEach(function(el) { el.remove(); });^
 
       maintext.innerHTML += "<br><b>&gt;" + details.command + "</b><br>"
     + data;^
 
       var main = document.getElementById("main");^
       var textAdded = main.scrollHeight - main.scrollTop;
-      if (textAdded > $("#main").height()) { 
-         main.scrollTop += $("#main").height(); 
-      } else { 
-         main.scrollTop = main.scrollHeight;^ 
+      var mainHeight = main.offsetHeight;
+      if (textAdded > mainHeight) {
+         main.scrollTop += mainHeight;
+      } else {
+         main.scrollTop = main.scrollHeight;^
       }
       document.JACLGameForm.command.value = "";^
-      var sound = $('#maintext').find('audio')[0];^
+      var sound = maintext.querySelector('audio');^
       if (sound != null) {^
-         sound.play(); 
+         sound.play();
       }^
-      var jaclscript = $('#maintext').find('script')[0];^
-      if (jaclscript != null) {^ 
-         eval (jaclscript.text); 
+      var jaclscript = maintext.querySelector('script');^
+      if (jaclscript != null) {^
+         (new Function(jaclscript.text))();
       }^
-      $('#JACLCommandPrompt').focus();
-      return false; 
+      document.getElementById('JACLCommandPrompt').focus();
+      return false;
 .
 }
 
@@ -156,7 +157,7 @@ select VISITED topic
          set node_y + 30
 
          write node_x " " node_y "~);^"
-      endif   
+      endif
       set INDEX + 1
    until INDEX = 8
 endselect
@@ -182,16 +183,16 @@ select VISITED topic
    # ADD THE TOPIC'S LABEL TO THE CENTRE OF THE NODE
    set node_x + 30
    set node_y + 30
-   write "var label = paper.text(" node_x ", " node_y ", ~" 
+   write "var label = paper.text(" node_x ", " node_y ", ~"
    split array_count topic{The} " " label
 
    if array_count = 0
-      write topic{The}         
+      write topic{The}
      else
       set INDEX = 0
       repeat
          write label[INDEX]
-         write "\n"            
+         write "\n"
          set INDEX + 1
       until INDEX = array_count
    endif

--- a/projects/include/webinterface.library
+++ b/projects/include/webinterface.library
@@ -27,6 +27,17 @@ print:
    }^
 .
 #include "ajax.library"
+print:
+   function submitForm(e) {^
+        e.preventDefault();^
+        ajaxForm({^
+             command: document.getElementById('JACLCommandPrompt').value,^
+             replace: false,^
+             element: "#maintext"^
+        });^
+        return false;^
+   }^
+.
 write "</script>^"
 write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
 write "</head>^"
@@ -67,24 +78,12 @@ write "<div id=~footer~>^"
 write "<div class=~directions~>"
 execute "+exits"
 write "</div>"
-write "<form id=~commandForm~ name=~JACLGameForm~ method=~get~ autocomplete=~off~>"
+write "<form id=~commandForm~ name=~JACLGameForm~ method=~get~ autocomplete=~off~ onsubmit=~return submitForm(event);~>"
 write "<div class=~command_prompt~>^"
 prompt "KeyPressed();"
 print:
    </div>
    </form></div>^
-   <script>
-          function submitForm(e) {^
-               e.preventDefault();^
-               ajaxForm({^
-                    command: document.getElementById('JACLCommandPrompt').value,^
-                    replace: false,^
-                    element: "#maintext"^
-               });^
-               return false;^
-          }^
-          document.getElementById('commandForm').addEventListener('submit', submitForm);^
-   </script>^
    </body></html>^
 .
 set linebreaks = true

--- a/projects/script.jacl
+++ b/projects/script.jacl
@@ -1,6 +1,6 @@
 #!../bin/cgijacl
 
-string game_title       "jQuery Example"
+string game_title       "JavaScript Example"
 constant game_author    "Stuart Allen"
 constant ifid           "JACL-011"
 
@@ -10,7 +10,7 @@ string environment
 getenv environment "SERVER_SOFTWARE"
 write "Server is ~" environment "~.^^"
 
-write "^^Welcome to the jQuery example game.^"
+write "^^Welcome to the JavaScript example game.^"
 execute "+look_around"
 }
 
@@ -29,7 +29,7 @@ object button : change title button
 if interpreter = CGI
    print:
      <script>
-        $('h1:first').text("Button has been pressed");
+        document.querySelector('h1').textContent = "Button has been pressed";
      </script>
    .
 write "You press the ~Change Title~ button.^


### PR DESCRIPTION
## Summary
- Replace jQuery `$.ajax()` with the native `fetch()` API in `ajax.library`
- Replace all jQuery DOM methods (`$()`, `.find()`, `.html()`, `.append()`, `.submit()`, `.click()`, `.height()`, `.focus()`, `.remove()`) with vanilla JS equivalents (`document.getElementById`, `querySelector`, `addEventListener`, etc.)
- Upgrade HTML4 transitional doctypes to HTML5 across all web libraries
- Replace `eval()` with `(new Function(...))()` for script execution in `webinterface.library`
- Remove deprecated `XMLHttpRequest`/ActiveX fallback in `french_webinterface.library`, replaced with `fetch()`
- Remove Facebook SDK from `dangarstu.library`
- Update `ajax.jacl` and `script.jacl` game files to match

**jQuery is no longer required by any bundled library or game.**

### Files changed

| File | Changes |
|------|---------|
| `ajax.library` | `$.ajax()` -> `fetch()`, `$().html/append` -> `querySelector().innerHTML` |
| `webinterface.library` | HTML5, no jQuery, `addEventListener`, `fetch()` |
| `webapp.library` | Removed jQuery `<script>` tag |
| `dangarstu.library` | HTML5, removed jQuery + Facebook SDK |
| `french_webinterface.library` | HTML5, `XMLHttpRequest` -> `fetch()` |
| `ajax.jacl` | `$().click()` -> `addEventListener` |
| `script.jacl` | `$().text()` -> `querySelector().textContent` |

## Test plan
- [ ] Test `webinterface.library` games (grail.jacl, bloodyguns.jacl, dragon.jacl, oyster.jacl) in browser — verify AJAX commands, scrolling, sound, and script execution work
- [ ] Test `webapp.library` apps (tasks.jacl, bumper.jacl, etc.) still load and function
- [ ] Test ajax.jacl demo project
- [ ] Verify no remaining references to jQuery in any library or game file

🤖 Generated with [Claude Code](https://claude.com/claude-code)