### PR TITLE
Fix ajax.library: use write instead of print for .then() chains

### DIFF
--- a/projects/include/ajax.library
+++ b/projects/include/ajax.library
@@ -5,11 +5,9 @@ if remote_user = false
 else
 	write ";^"
 endif
-print:
-	fetch(url_string)
-		.then(function(response) { return response.text(); })
-		.then(function(data) {^
-.
+write "fetch(url_string)^"
+write "  .then(function(response) { return response.text(); })^"
+write "  .then(function(data) {^"
 ifexecute "+local_success"
 	# RESULT HANDLED BY LOCAL APPLICATION
 else
@@ -22,10 +20,8 @@ print:
 			}^
 .
 endif
-print:
-		});^
-}^
-.
+write "  });^"
+write "}^"
 write "function ajaxRequest(details) {^"
 write "var url_string = ~" $url "?ajax=true&command=~ + encodeURIComponent(details.command)"
 if remote_user = false
@@ -33,11 +29,9 @@ if remote_user = false
 else
 	write ";^"
 endif
-print:
-	fetch(url_string)
-		.then(function(response) { return response.text(); })
-		.then(function(data) {^
-.
+write "fetch(url_string)^"
+write "  .then(function(response) { return response.text(); })^"
+write "  .then(function(data) {^"
 ifexecute "+local_success"
 	# RESULT HANDLED BY LOCAL APPLICATION
 else
@@ -50,7 +44,5 @@ else
 			}^
    .
 endif
-print:
-		});^
-}^
-.
+write "  });^"
+write "}^"


### PR DESCRIPTION
JACL's print: blocks end when they encounter a line starting with "." which conflicts with JavaScript's .then() method chaining. Replace the print: blocks containing .then() with write statements to avoid JACL interpreting them as end-of-print markers.