### PR TITLE
Merge GUI/Mobile modes into webinterface.library

### DIFF
--- a/projects/include/french_webinterface.library
+++ b/projects/include/french_webinterface.library
@@ -1,248 +1,57 @@
-# STANDARD HEADERS AND FOOTERS FOR WEB-BASED INTERACTIVE FICTION
+# DEPRECATED: Use webinterface.library with French localisation strings instead.
+# This file is kept for backwards compatibility and will be removed in a future release.
+#
+# To migrate, replace:
+#   #include "french_webinterface.library"
+# with:
+#   #include "webinterface.library"
+# and add the following to your +bootstrap function:
+#   setstring game_language "fr"
+#   setstring link_about "&Agrave; propos"
+#   setstring link_restart "Recommencer"
+#   setstring link_hint "Astuces"
+#   setstring msg_standard_mode "L'interface passe en mode standard."
+#   setstring label_you_can_see "Vous pouvez voir :"
+#   setstring label_you_carry "Vous portez :"
+#   setstring button_image_path "/images/buttons/fr"
+#   setstring btn_look "regarder"
+#   setstring btn_take "prendre"
+#   setstring btn_drop "laisser"
+#   setstring btn_use "utiliser"
+#   setstring btn_open "ouvrir"
+#   setstring btn_close "fermer"
+#   setstring btn_talk "parler a"
+#   setstring btn_wear "wear"
+#   setstring btn_remove "retirer"
+#   setstring btn_touch "toucher"
+#   setstring btn_wait "attendre"
+#   setstring btn_give "donner"
+#   setstring btn_break "casser"
+#   setstring btn_consume "manger"
+#   setstring btn_enter "entrer"
 
-parameter interface gui_mode
+string game_language "fr"
+string link_about "&Agrave; propos"
+string link_restart "Recommencer"
+string link_hint "Astuces"
+string msg_standard_mode "L'interface passe en mode standard."
+string label_you_can_see "Vous pouvez voir :"
+string label_you_carry "Vous portez :"
+string button_image_path "/images/buttons/fr"
+string btn_look "regarder"
+string btn_take "prendre"
+string btn_drop "laisser"
+string btn_use "utiliser"
+string btn_open "ouvrir"
+string btn_close "fermer"
+string btn_talk "parler a"
+string btn_wear "wear"
+string btn_remove "retirer"
+string btn_touch "toucher"
+string btn_wait "attendre"
+string btn_give "donner"
+string btn_break "casser"
+string btn_consume "manger"
+string btn_enter "entrer"
 
-integer gui_mode STANDARD
-
-string current_image "none"
-
-constant STANDARD	1
-constant GUI		2
-constant MOBILE		3
-
-grammar standard >standard
-
-{+standard
-set gui_mode = STANDARD
-set time = false
-write "L'interface passe en mode standard.^"
-}
-
-{+header
-set linebreaks = false
-print:
-<!DOCTYPE html>
-.
-write "<html lang=~fr~><head>"
-write "<meta charset=~UTF-8~>"
-write "<title>" game_title "</title>"
-execute "+styles"
-print:
-   <script>^
-   function changeInterface() {^
-      document.JACLInterfaceForm.submit(); }^
-   function putFocus(formInst, elementInst) {^
-      if (document.forms.length > 0) {^
-         document.forms[formInst].elements[elementInst].focus(); }}^
-.
-if gui_mode = STANDARD : gui_mode = MOBILE
-   print:
-      function userCommand() {^
-      var user_id = document.JACLGameForm.user_id.value;^
-      var command = document.JACLGameForm.command.value;^
-   .
-   write "var url_string = ~" $url
-   print:
-?user_id="+user_id+"&command="+encodeURIComponent(command)+"&ajax=true";^
-      fetch(url_string)^
-         .then(function(response) { return response.text(); })^
-         .then(function(data) {^
-            var maintext = document.getElementById("maintext");^
-            maintext.innerHTML += "<br><b>&gt;" + command + "</b><br>" + data;^
-            var main = document.getElementById("main");^
-            main.scrollTop = main.scrollHeight;^
-            document.JACLGameForm.command.value = "";^
-.
-if gui_mode = MOBILE
-   write "putFocus(0, 0);^"
-else
-   write "putFocus(1, 0);^"
-endif
-print:
-      });^
-      return false; }^
-   .
-endif
-write "</script>^"
-write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
-write "</head>^"
-if gui_mode = MOBILE
-   write "<body onLoad=~putFocus(0, 0);~>^"
-else
-   write "<body onLoad=~putFocus(1, 0);~>^"
-endif
-write "<div id=~header~>"
-ifstring title_image = "none"
-  write "<h1>" game_title "</h1>"
-else
-  write "<img class=~titleimage~ alt=~" game_title "~ src=~" title_image "~>"
-endif
-if gui_mode != MOBILE
-   write "<form name=~JACLInterfaceForm~ method=get>^"
-   write "<div class=~links~>
-   write "| "
-   write "Interface: "
-   write "Standard<input type=~radio~ name=~interface~ value=~1~"
-   if gui_mode = STANDARD
-      write " checked onclick=~return changeInterface();~>"
-   else
-      write " onclick=~return changeInterface();~>"
-   endif
-   write " GUI<input type=~radio~ name=~interface~ value=~2~"
-   if gui_mode = GUI
-      write " checked onclick=~return changeInterface();~>"
-   else
-      write " onclick=~return changeInterface();~>"
-   endif
-   write " Mobile<input type=~radio~ name=~interface~ value=~3~"
-   if gui_mode = MOBILE
-      write " checked onclick=~return changeInterface();~>"
-   else
-      write " onclick=~return changeInterface();~>"
-   endif
-   hidden
-   write "<input type=~hidden~ name=~command~ value=~look~>"
-   write " | "
-   hyperlink "Instructions" "instructions" "header"
-   write " | "
-   hyperlink "À propos" "about" "header"
-   write " | "
-   hyperlink "Recommencer" "restart" "header"
-   write " | "
-   hyperlink "Astuces" "hint" "header"
-   write " |"
-   write "</div>^"
-   write "</form>^"
-endif
-write "</div>^"
-write "<div id=~main~>^"
-write "<div id=~maintext~ class=~maintext~>^"
-set linebreaks = true
-}
-
-{+footer
-set linebreaks = false
-write "</div>"
-write "</div>"
-if gui_mode != MOBILE
-   ifstring current_image != "none"
-      write "<div class=~picture~>"
-      write "<img class=~main~ src=~" current_image "~>"
-      write "</div>"
-   endif
-endif
-write "<div id=~footer~>^"
-   write "<div class=~directions~>"
-   execute "+exits"
-   write "</div>"
-if gui_mode = STANDARD : gui_mode = MOBILE
-   if gui_mode = STANDARD
-      write "<form name=~JACLGameForm~ method=get onsubmit=~return userCommand();~>^"
-      write "<div class=~prompt_text~>"
-      write command_prompt
-      write "</div>^"
-   else
-      write "<form name=~JACLGameForm~ method=get>^"
-   endif
-   write "<div class=~command_prompt~>^"
-   prompt
-endif
-if gui_mode = GUI
-   write "<form name=~JACLGameForm~ method=get>^"
-   write "<div class=~interface~>^"
-   button "regarder" "/images/buttons/fr/look.png"
-   button "prendre" "/images/buttons/fr/take.png"
-   button "laisser" "/images/buttons/fr/drop.png"
-   write "<br>"
-   button "utiliser" "/images/buttons/fr/use.png"
-   button "ouvrir" "/images/buttons/fr/open.png"
-   button "fermer" "/images/buttons/fr/close.png"
-   write "<br>"
-   button "parler à" "/images/buttons/fr/talkto.png"
-   button "wear" "/images/buttons/fr/wear.png"
-   button "retirer" "/images/buttons/fr/remove.png"
-   write "<br>"
-   button "toucher" "/images/buttons/fr/touch.png"
-   button "attendre" "/images/buttons/fr/wait.png"
-   button "donner" "/images/buttons/fr/give.png"
-   write "<br>"
-   button "casser" "/images/buttons/fr/break.png"
-   button "manger" "/images/buttons/fr/consume.png"
-   button "entrer" "/images/buttons/fr/enter.png"
-   write "</div>"
-   write "<div class=~interface~>^"
-   write "<b>Vous pouvez voir :</b><br>^"
-   write "<select name=~noun~ size=8>"
-   loop
-      ifall here grandof noun3 : player !grandof noun3 : noun3 hasnt LOCATION
-         option noun3
-      else
-         if noun3 = player
-            option noun3
-         endif
-      endif
-   endloop
-   write "</select>"
-   write "</div>"
-   write "<div class=~interface~>^"
-   write "<b>Vous portez :</b><br>^"
-   write "<select name=~noun~ size=8>"
-   loop
-      ifall player grandof noun3 : noun3 != player
-         option noun3
-      endif
-   endloop
-   write "</select>"
-   hidden
-   write "</div>"
-   write "<div class=~compass~>"
-   ifall here(northwest) != nowhere : here(northwest) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/northwest_blue.png~>" "nw"
-   else
-      write "<img src=~/images/compass/northwest.png~>"
-   endif
-   ifall here(north) != nowhere : here(north) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/north_blue.png~>" "n"
-   else
-      write "<img src=~/images/compass/north.png~>"
-   endif
-   ifall here(northeast) != nowhere : here(northeast) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/northeast_blue.png~>" "ne"
-   else
-      write "<img src=~/images/compass/northeast.png~>"
-   endif
-   write "<br>"
-   ifall here(west) != nowhere : here(west) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/west_blue.png~>" "w"
-   else
-      write "<img src=~/images/compass/west.png~>"
-   endif
-   write "<img src=~/images/compass/centre.png~>"
-   ifall here(east) != nowhere : here(east) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/east_blue.png~>" "east"
-   else
-      write "<img src=~/images/compass/east.png~>"
-   endif
-   write "<br>"
-   ifall here(southwest) != nowhere : here(southwest) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/southwest_blue.png~>" "sw"
-   else
-      write "<img src=~/images/compass/southwest.png~>"
-   endif
-   ifall here(south) != nowhere : here(south) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/south_blue.png~>" "s"
-   else
-      write "<img src=~/images/compass/south.png~>"
-   endif
-   ifall here(southeast) != nowhere : here(southeast) != NO_GO
-      hyperlink "<img class=~compass~ src=~/images/compass/southeast_blue.png~>" "se"
-   else
-      write "<img src=~/images/compass/southeast.png~>"
-   endif
-   write "</div>^"
-endif
-write "</div>"
-write "</form></div>^"
-write "</body></html>^"
-set linebreaks = true
-}
+#include "webinterface.library"

--- a/projects/include/webinterface.library
+++ b/projects/include/webinterface.library
@@ -1,7 +1,49 @@
 # STANDARD HEADERS AND FOOTERS FOR WEB-BASED INTERACTIVE FICTION
 
+parameter interface gui_mode
+
+integer gui_mode STANDARD
+
 string current_image "none"
 string game_language "en"
+
+constant STANDARD	1
+constant GUI		2
+constant MOBILE		3
+
+# LOCALISATION STRINGS -- OVERRIDE THESE WITH setstring IN +bootstrap
+string link_instructions "Instructions"
+string link_about "About"
+string link_restart "Restart"
+string link_hint "Hint"
+string msg_standard_mode "Setting interface to standard mode."
+string label_you_can_see "You can see:"
+string label_you_carry "You are carrying:"
+string button_image_path "/images/buttons"
+string btn_look "look"
+string btn_take "take"
+string btn_drop "drop"
+string btn_use "use"
+string btn_open "open"
+string btn_close "close"
+string btn_talk "talk to"
+string btn_wear "wear"
+string btn_remove "remove"
+string btn_touch "touch"
+string btn_wait "wait"
+string btn_give "give"
+string btn_break "break"
+string btn_consume "consume"
+string btn_enter "enter"
+
+grammar standard >standard
+
+{+standard
+set gui_mode = STANDARD
+set time = false
+write msg_standard_mode
+write "^"
+}
 
 {+header
 set linebreaks = false
@@ -53,6 +95,7 @@ print:
       document.JACLInterfaceForm.submit();
    }^
 .
+if gui_mode = STANDARD : gui_mode = MOBILE
 #include "ajax.library"
 print:
    function submitForm(e) {^
@@ -65,6 +108,7 @@ print:
         return false;^
    }^
 .
+endif
 write "</script>^"
 write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
 write "</head>^"
@@ -75,17 +119,43 @@ ifstring title_image = "none"
 else
   write "<img class=~titleimage~ alt=~" game_title "~ src=~" title_image "~>"
 endif
-write "<div class=~links~>
-write " | "
-hyperlink "Instructions" "instructions" "header"
-write " | "
-hyperlink "About" "about" "header"
-write " | "
-hyperlink "Restart" "restart" "header"
-write " | "
-hyperlink "Hint" "hint" "header"
-write " |"
-write "</div>^"
+if gui_mode != MOBILE
+   write "<form name=~JACLInterfaceForm~ method=get>^"
+   write "<div class=~links~>"
+   write "| "
+   write "Interface: "
+   write "Standard<input type=~radio~ name=~interface~ value=~1~"
+   if gui_mode = STANDARD
+      write " checked onclick=~return changeInterface();~>"
+   else
+      write " onclick=~return changeInterface();~>"
+   endif
+   write " GUI<input type=~radio~ name=~interface~ value=~2~"
+   if gui_mode = GUI
+      write " checked onclick=~return changeInterface();~>"
+   else
+      write " onclick=~return changeInterface();~>"
+   endif
+   write " Mobile<input type=~radio~ name=~interface~ value=~3~"
+   if gui_mode = MOBILE
+      write " checked onclick=~return changeInterface();~>"
+   else
+      write " onclick=~return changeInterface();~>"
+   endif
+   hidden
+   write "<input type=~hidden~ name=~command~ value=~look~>"
+   write " | "
+   hyperlink link_instructions "instructions" "header"
+   write " | "
+   hyperlink link_about "about" "header"
+   write " | "
+   hyperlink link_restart "restart" "header"
+   write " | "
+   hyperlink link_hint "hint" "header"
+   write " |"
+   write "</div>^"
+   write "</form>^"
+endif
 write "</div>^"
 write "<div id=~main~>^"
 write "<div id=~maintext~ class=~maintext~>^"
@@ -96,23 +166,124 @@ set linebreaks = true
 set linebreaks = false
 write "</div>"
 write "</div>"
+if gui_mode != MOBILE
    ifstring current_image != "none"
       write "<div class=~picture~>"
       write "<img class=~main~ src=~" current_image "~>"
       write "</div>"
    endif
+endif
 write "<div id=~footer~>^"
 write "<div class=~directions~>"
 execute "+exits"
 write "</div>"
-write "<form id=~commandForm~ name=~JACLGameForm~ method=~get~ autocomplete=~off~ onsubmit=~return submitForm(event);~>"
-write "<div class=~command_prompt~>^"
-prompt "KeyPressed();"
-print:
-   </div>
-   </form></div>^
-   </body></html>^
-.
+if gui_mode = STANDARD : gui_mode = MOBILE
+   write "<form id=~commandForm~ name=~JACLGameForm~ method=~get~ autocomplete=~off~ onsubmit=~return submitForm(event);~>"
+   write "<div class=~command_prompt~>^"
+   prompt "KeyPressed();"
+   print:
+      </div>
+      </form>
+   .
+endif
+if gui_mode = GUI
+   write "<form name=~JACLGameForm~ method=get>^"
+   write "<div class=~interface~>^"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/look.png~ name=~verb~ value=~" btn_look "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/take.png~ name=~verb~ value=~" btn_take "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/drop.png~ name=~verb~ value=~" btn_drop "~>"
+   write "<br>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/use.png~ name=~verb~ value=~" btn_use "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/open.png~ name=~verb~ value=~" btn_open "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/close.png~ name=~verb~ value=~" btn_close "~>"
+   write "<br>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/talkto.png~ name=~verb~ value=~" btn_talk "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/wear.png~ name=~verb~ value=~" btn_wear "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/remove.png~ name=~verb~ value=~" btn_remove "~>"
+   write "<br>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/touch.png~ name=~verb~ value=~" btn_touch "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/wait.png~ name=~verb~ value=~" btn_wait "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/give.png~ name=~verb~ value=~" btn_give "~>"
+   write "<br>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/break.png~ name=~verb~ value=~" btn_break "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/consume.png~ name=~verb~ value=~" btn_consume "~>"
+   write "<input class=~button~ type=~image~ src=~" button_image_path "/enter.png~ name=~verb~ value=~" btn_enter "~>"
+   write "</div>"
+   write "<div class=~interface~>^"
+   write "<b>" label_you_can_see "</b><br>^"
+   write "<select name=~noun~ size=8>"
+   loop
+      ifall here grandof noun3 : player !grandof noun3 : noun3 hasnt LOCATION
+         option noun3
+      else
+         if noun3 = player
+            option noun3
+         endif
+      endif
+   endloop
+   write "</select>"
+   write "</div>"
+   write "<div class=~interface~>^"
+   write "<b>" label_you_carry "</b><br>^"
+   write "<select name=~noun~ size=8>"
+   loop
+      ifall player grandof noun3 : noun3 != player
+         option noun3
+      endif
+   endloop
+   write "</select>"
+   hidden
+   write "</div>"
+   write "<div class=~compass~>"
+   ifall here(northwest) != nowhere : here(northwest) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/northwest_blue.png~>" "nw"
+   else
+      write "<img src=~/images/compass/northwest.png~>"
+   endif
+   ifall here(north) != nowhere : here(north) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/north_blue.png~>" "n"
+   else
+      write "<img src=~/images/compass/north.png~>"
+   endif
+   ifall here(northeast) != nowhere : here(northeast) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/northeast_blue.png~>" "ne"
+   else
+      write "<img src=~/images/compass/northeast.png~>"
+   endif
+   write "<br>"
+   ifall here(west) != nowhere : here(west) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/west_blue.png~>" "w"
+   else
+      write "<img src=~/images/compass/west.png~>"
+   endif
+   write "<img src=~/images/compass/centre.png~>"
+   ifall here(east) != nowhere : here(east) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/east_blue.png~>" "east"
+   else
+      write "<img src=~/images/compass/east.png~>"
+   endif
+   write "<br>"
+   ifall here(southwest) != nowhere : here(southwest) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/southwest_blue.png~>" "sw"
+   else
+      write "<img src=~/images/compass/southwest.png~>"
+   endif
+   ifall here(south) != nowhere : here(south) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/south_blue.png~>" "s"
+   else
+      write "<img src=~/images/compass/south.png~>"
+   endif
+   ifall here(southeast) != nowhere : here(southeast) != NO_GO
+      hyperlink "<img class=~compass~ src=~/images/compass/southeast_blue.png~>" "se"
+   else
+      write "<img src=~/images/compass/southeast.png~>"
+   endif
+   write "</div>^"
+   hidden
+   write "</form>"
+endif
+write "</div>^"
+write "</body></html>^"
 set linebreaks = true
 }
 


### PR DESCRIPTION
## Summary
- Consolidate `french_webinterface.library` and `webinterface.library` into a single library supporting three interface modes: Standard (text input with AJAX), GUI (compass, image buttons, noun lists), and Mobile
- All UI text is driven by localisation string variables with English defaults — games override them via `setstring` in `+bootstrap` or by declaring strings before the `#include`
- `french_webinterface.library` becomes a thin backwards-compatible wrapper that sets French strings and includes the main library
- Modern features (AJAX via `ajax.library`, speech synthesis, audio/script handling) are preserved for Standard and Mobile modes
- GUI mode uses full page submission (compass/inventory need full refresh)

## Localisation strings added
- Nav links: `link_instructions`, `link_about`, `link_restart`, `link_hint`
- GUI labels: `label_you_can_see`, `label_you_carry`, `msg_standard_mode`
- 15 button commands: `btn_look`, `btn_take`, `btn_drop`, `btn_use`, `btn_open`, `btn_close`, `btn_talk`, `btn_wear`, `btn_remove`, `btn_touch`, `btn_wait`, `btn_give`, `btn_break`, `btn_consume`, `btn_enter`
- `button_image_path` for language-specific button images

## Test plan
- [ ] Load an English game in Standard mode — verify text input with AJAX works
- [ ] Switch to GUI mode — verify buttons, compass, noun lists, and full-page submission work
- [ ] Switch to Mobile mode — verify text input works without interface switcher
- [ ] Load a French game using `french_webinterface.library` — verify backwards compatibility (French labels, buttons, compass)
- [ ] Test speech synthesis (`voice`/`unvoice`) in Standard mode
- [ ] Verify `game_language` sets `<html lang=...>` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)