### PR TITLE
Add word lookup command to Spanish verbs library

### DIFF
--- a/projects/include/spanish_verbs.library
+++ b/projects/include/spanish_verbs.library
@@ -610,6 +610,27 @@ write "`JUEGOS' SE REFIERE A MODELOS, SIMULACIONES Y JUEGOS QUE TIENEN "
 write "APLICACIONES TACTICAS Y ESTRATEGICAS.^"
 }
 
+integer palabra_encontrada
+
+grammar lookup $string >lookup_word
+grammar dict $string >lookup_word
+grammar significado $string >lookup_word
+grammar definir $string >lookup_word
+
+{+lookup_word
+set palabra_encontrada = false
+iterate "spanish_words.csv" skip_header
+   ifstring field[0] = $string
+      write "The word " $string " means " field[1] ".^"
+      set palabra_encontrada = true
+   endif
+enditerate
+if palabra_encontrada = false
+   write "La palabra ~" $string "~ no se encontró.^"
+endif
+set time = false
+}
+
 grammar abrazar		>hug_only
 grammar consolar	>hug_only
 grammar hug			>hug_only


### PR DESCRIPTION
## Summary
- Add `significado`, `definir`, `lookup`, and `dict` grammar commands to the Spanish verbs library
- These search the `spanish_words.csv` dictionary (2,351 entries, already on master) for word translations
- Uses the same `iterate` pattern as the Indonesian dictionary lookup (`arti` command)

## Test plan
- [ ] Build with `--with-language=spanish`
- [ ] Run a Spanish game and type `significado hola` — should show "hello"
- [ ] Type `significado "buenos días"` — should show compound word lookup
- [ ] Type `significado asdfgh` — should show "not found" message in Spanish

🤖 Generated with [Claude Code](https://claude.com/claude-code)