### PR TITLE
glkterm: exit cleanly on stdin EOF instead of busy-looping at 100% CPU

### DIFF
--- a/src/glkterm/gtevent.c
+++ b/src/glkterm/gtevent.c
@@ -8,6 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <poll.h>
+#include <unistd.h>
 
 #ifdef OPT_TIMED_INPUT
 #include <sys/time.h>
@@ -82,7 +84,20 @@ void glk_select(event_t *event)
             continue;
         }
 
-        /* key == ERR; it's an idle event */
+        /* key == ERR; it's an idle event.
+           If stdin is a closed pipe (writer hung up), ncurses' getch()
+           will return ERR on every call without blocking, busy-looping
+           this thread at 100% CPU. Detect that case via poll() and
+           exit cleanly rather than spin forever. */
+        if (!isatty(STDIN_FILENO)) {
+            struct pollfd pfd;
+            pfd.fd = STDIN_FILENO;
+            pfd.events = POLLIN;
+            pfd.revents = 0;
+            if (poll(&pfd, 1, 0) > 0 && (pfd.revents & POLLHUP)) {
+                gli_fast_exit();
+            }
+        }
         
 #ifdef OPT_USE_SIGNALS
 


### PR DESCRIPTION
## Summary

- When jacl is run with stdin redirected from a closed pipe (e.g. `echo cmd | jacl game.jacl`), the GlkTerm event loop spins at 100% CPU until the process is killed externally.
- Root cause: ncurses' `getch()` returns `ERR` immediately on EOF (because `select()` reports the fd readable for EOF and `read()` returns 0 instantly), and `glk_select()` had no way to distinguish "no input yet" from "writer has hung up."
- Fix: in the `ERR` branch of `glk_select()`, when stdin is not a TTY, `poll()` it with a zero timeout. `POLLHUP` is set only when the pipe writer has closed, so on `POLLHUP` we call `gli_fast_exit()` to close streams, restore the terminal via `endwin()`, and exit 0.

Found because seven `jacl` processes had accumulated on a dev machine after piped smoke tests, burning a combined ~700% CPU for over a day.

## Safety

- Gated on `!isatty(STDIN_FILENO)` so interactive TTY use is unchanged.
- A still-open pipe (writer alive, no data yet) reports no events from `poll(timeout=0)` and falls through to the existing idle handling — only an actual hung-up writer triggers the exit.

## Diagnosis

`sample` on a stuck process showed the loop:

```
glk_main → glk_select → wgetch (ncurses)
              → _nc_wgetch
                 ├─ _nc_timed_wait → select()   (1396 / 2560 samples)
                 └─ read()                       (1124 / 2560 samples)
```

`select()` and `read()` both returning instantly because the pipe was at EOF, with `glk_select()` looping the result back as an "idle event."

## Test plan

- [x] `echo "" | ./jacl desa.jacl` exits cleanly within 2s (previously: spun forever)
- [ ] Interactive TTY launch still accepts input and runs normally
- [ ] `cat commands.txt | ./jacl game.jacl` runs the commands then exits on EOF (instead of hanging)
- [ ] Verify on Linux as well as macOS — `POLLHUP` semantics match across both

🤖 Generated with [Claude Code](https://claude.com/claude-code)