### PR TITLE
Optional Google Sign-In for fcgijacl

### DIFF
--- a/etc/cgijacl.conf
+++ b/etc/cgijacl.conf
@@ -8,3 +8,24 @@ include		"/usr/local/jacl/projects/include/"
 temp			"/usr/local/jacl/projects/temp/"
 prefer_remote_user
 cookie_expiry  20000
+
+# Optional Google Sign-In. When BOTH google_client_id and
+# session_secret are set, fcgijacl renders a "Sign in with Google"
+# button in the header and routes save files to "google_<sub>.auto"
+# for signed-in players (anonymous players keep working unchanged).
+#
+# google_client_id  -- the OAuth 2.0 Client ID (the *.apps.googleusercontent.com
+#                      string) from Google Cloud Console -> APIs & Services
+#                      -> Credentials. Add your site origin to "Authorised
+#                      JavaScript origins".
+# session_secret    -- 32+ bytes of random hex used to HMAC-sign the
+#                      jacl_session cookie. Generate once with:
+#                          openssl rand -hex 32
+#                      Treat it like a private key -- if it leaks, anyone
+#                      can mint cookies for any sub. Rotating invalidates
+#                      every existing session.
+# session_max_age   -- Cookie lifetime in seconds. Defaults to 30 days.
+#
+# google_client_id  "1234567890-abcdef.apps.googleusercontent.com"
+# session_secret    "REPLACE_ME_WITH_OUTPUT_OF_openssl_rand_hex_32"
+# session_max_age   2592000

--- a/etc/google-auth-setup.md
+++ b/etc/google-auth-setup.md
@@ -1,0 +1,108 @@
+# Google Sign-In setup for fcgijacl
+
+Optional. Lets returning players resume their saved game by signing
+in with Google. Anonymous play continues to work unchanged when
+this is not configured.
+
+## 1. Build dependencies
+
+The `auth.c` module needs libcurl, jansson, and OpenSSL. On
+Debian/Ubuntu (the `make apache` target):
+
+```sh
+sudo apt install libcurl4-openssl-dev libjansson-dev libssl-dev
+```
+
+On macOS:
+
+```sh
+brew install curl jansson openssl@3
+```
+
+If `./configure` can't find all three, fcgijacl is built against
+`auth_stub.c` instead and Sign-In is silently disabled at runtime.
+You'll see `Google Sign-In disabled (need libcurl, jansson, openssl)`
+in the configure summary.
+
+## 2. Create a Google OAuth Client ID
+
+1. Go to <https://console.cloud.google.com/apis/credentials>.
+2. Create or select a project.
+3. **Create Credentials -> OAuth client ID -> Web application**.
+4. Under **Authorised JavaScript origins** add the exact origin
+   players will load the game from, e.g. `https://jacl.example.com`.
+   You don't need a redirect URI -- Google Identity Services posts
+   the ID token directly to JS, which fcgijacl then verifies.
+5. Copy the resulting Client ID -- it looks like
+   `1234567890-abcdef.apps.googleusercontent.com`.
+
+## 3. Generate a session secret
+
+This is the HMAC key fcgijacl uses to sign session cookies. Treat it
+like a private key: anyone who knows it can mint cookies for any
+Google account.
+
+```sh
+openssl rand -hex 32
+```
+
+## 4. Configure cgijacl.conf
+
+Add (or uncomment) these lines in `/etc/cgijacl.conf`:
+
+```
+google_client_id  "1234567890-abcdef.apps.googleusercontent.com"
+session_secret    "<the openssl-rand output from above>"
+session_max_age   2592000
+```
+
+`session_max_age` is the cookie lifetime in seconds; 2592000 = 30 days.
+
+## 5. Restart Apache / fcgijacl
+
+```sh
+sudo systemctl restart apache2
+```
+
+mod_fcgid will re-spawn fcgijacl workers and they'll pick up the new
+config. The header should now show a Google button next to the Hint
+link; clicking it runs the GIS flow and reloads the page with the
+player signed in.
+
+## What it actually does
+
+* On a successful Google Sign-In the frontend POSTs the ID token to
+  `?auth=google&credential=<jwt>`.
+* fcgijacl verifies the token (RS256, against the live Google JWKS),
+  checks `iss`/`aud`/`exp`, and extracts the `sub` claim.
+* It returns a `Set-Cookie: jacl_session=<sub>.<expiry>.<hmac>`
+  cookie (`HttpOnly; SameSite=Lax`).
+* On every subsequent request, the cookie is verified and `user_id`
+  is set to `google_<sub>`, which is what save files key off. So a
+  player who signs in on a different device, or after a year, gets
+  their game back.
+* `?auth=logout` clears the cookie.
+
+If `google_client_id` is empty or unset, none of this code path
+runs, no auth-related JS is emitted, and the game behaves exactly
+as before.
+
+## Game-side hooks
+
+These JACL constants are populated on every request:
+
+* `google_client_id` -- the configured client ID, or empty string
+  when auth is off. Use this to gate UI/behaviour:
+
+  ```jacl
+  ifstring google_client_id != ""
+      write "Sign in to save your progress.^"
+  endif
+  ```
+
+* `google_signed_in` -- 1 when the request has a valid session
+  cookie, 0 otherwise.
+
+* `google_sub` -- the Google subject claim for the signed-in user
+  (empty when anonymous). Useful for per-player branching, but
+  remember it's an opaque identifier, not an email address.

--- a/etc/google-auth-setup.md
+++ b/etc/google-auth-setup.md
@@ -58,7 +58,21 @@ session_max_age   2592000
 
 `session_max_age` is the cookie lifetime in seconds; 2592000 = 30 days.
 
-## 5. Restart Apache / fcgijacl
+## 5. Serve over HTTPS
+
+Google Identity Services only runs on HTTPS origins (the sole
+exception is `http://localhost` for local testing). The origin you
+configured in step 2 must match your Apache vhost **exactly** -- same
+scheme, same hostname, no port, no trailing slash. So if Apache is
+serving `https://jacl.example.com`, the Google Console origin must be
+`https://jacl.example.com` and nothing else.
+
+`etc/jacl-apache.conf` ships with a commented-out `:443` vhost
+template you can adapt. fcgijacl automatically adds the `Secure` flag
+to the session cookie when Apache sets `HTTPS=on`, so once the vhost
+is live there's nothing further to do on the cookie side.
+
+## 6. Restart Apache / fcgijacl
 
 ```sh
 sudo systemctl restart apache2

--- a/etc/jacl-apache.conf
+++ b/etc/jacl-apache.conf
@@ -28,3 +28,36 @@
     Require all granted
   </Directory>
 </IfModule>
+
+# ----------------------------------------------------------------------
+# Optional: HTTPS vhost for Google Sign-In
+#
+# Google Identity Services requires the page origin to be HTTPS
+# (localhost is the only exception). The session cookie fcgijacl
+# emits adds the Secure flag automatically when Apache sets HTTPS=on,
+# so wiring up SSL is all that's needed on the Apache side.
+#
+# Replace jacl.example.com and the certificate paths to suit, then
+# point Google Cloud Console -> Credentials -> "Authorised JavaScript
+# origins" at the same https://jacl.example.com (no port, no path,
+# no trailing slash).
+# ----------------------------------------------------------------------
+#
+# <VirtualHost *:80>
+#   ServerName jacl.example.com
+#   Redirect permanent / https://jacl.example.com/
+# </VirtualHost>
+#
+# <VirtualHost *:443>
+#   ServerName jacl.example.com
+#
+#   SSLEngine on
+#   SSLCertificateFile      /etc/letsencrypt/live/jacl.example.com/fullchain.pem
+#   SSLCertificateKeyFile   /etc/letsencrypt/live/jacl.example.com/privkey.pem
+#
+#   # Recommended hardening once HTTPS is verified working:
+#   # Header always set Strict-Transport-Security "max-age=31536000"
+#   # Header always set Referrer-Policy "strict-origin-when-cross-origin"
+#
+#   Include /etc/apache2/conf-available/jacl-apache.conf
+# </VirtualHost>

--- a/projects/include/webinterface.library
+++ b/projects/include/webinterface.library
@@ -239,6 +239,54 @@ print:
       main.insertAdjacentHTML('afterbegin', html);^
    }^
 
+   /* Google Sign-In: optional. The engine emits^
+    * window.JACL_GOOGLE_CLIENT_ID only when fcgijacl has both a^
+    * client_id and a session_secret configured, so the button is^
+    * only ever rendered on properly-set-up servers. */^
+   function jaclGoogleCallback(response) {^
+      var token = response && response.credential;^
+      if (!token) return;^
+      var body = 'auth=google&credential=' + encodeURIComponent(token);^
+      fetch(window.location.pathname + '?' + body, { credentials: 'same-origin' })^
+        .then(function(r) { return r.json(); })^
+        .then(function(j) {^
+           if (j && j.ok) window.location.reload();^
+        })^
+        .catch(function() {});^
+   }^
+
+   function jaclLogout() {^
+      fetch(window.location.pathname + '?auth=logout', { credentials: 'same-origin' })^
+        .then(function() { window.location.reload(); })^
+        .catch(function() {});^
+   }^
+
+   function jaclRenderGoogleAuth() {^
+      if (!window.JACL_GOOGLE_CLIENT_ID) return;^
+      var slot = document.getElementById('jaclAuthSlot');^
+      if (!slot) return;^
+      if (window.JACL_GOOGLE_SIGNED_IN) {^
+         slot.innerHTML = 'Signed in &middot; ' +^
+            '<a href="javascript:jaclLogout()">log out</a>';^
+         return;^
+      }^
+      if (!window.google || !google.accounts || !google.accounts.id) {^
+         /* GIS client not loaded yet -- retry once it arrives. */^
+         setTimeout(jaclRenderGoogleAuth, 200);^
+         return;^
+      }^
+      google.accounts.id.initialize({^
+         client_id: window.JACL_GOOGLE_CLIENT_ID,^
+         callback: jaclGoogleCallback,^
+         auto_select: false^
+      });^
+      slot.innerHTML = '<div id="jaclGoogleBtn"></div>';^
+      google.accounts.id.renderButton(^
+         document.getElementById('jaclGoogleBtn'),^
+         { theme: 'outline', size: 'medium', type: 'standard' }^
+      );^
+   }^
+
    function changeInterface() {^
       document.JACLInterfaceForm.submit();
    }^
@@ -469,6 +517,11 @@ write "</script>^"
 write "<script>window.jaclLang = '" game_language "';</script>"
 write "<script>window.jaclMapBg = '" maintext_colour "';</script>"
 write "<link rel=~icon~ href=~/images/favicon.ico~ type=~image/x-icon~>"
+ifstring google_client_id != ""
+   write "<script>window.JACL_GOOGLE_CLIENT_ID = '" google_client_id "';</script>"
+   write "<script>window.JACL_GOOGLE_SIGNED_IN = " google_signed_in ";</script>"
+   write "<script src=~https://accounts.google.com/gsi/client~ async defer></script>"
+endif
 ifexecute "+local_header"
    # GAME MAY INJECT ADDITIONAL HEAD CONTENT (extra stylesheets, scripts).
 endif
@@ -477,7 +530,7 @@ ifexecute "+library_header"
    # WITHOUT COLLIDING WITH THE GAME'S +local_header.
 endif
 write "</head>^"
-write "<body onLoad=~document.getElementById('JACLCommandPrompt').focus(); jaclOfferVoice(); jaclInitMic();~>^"
+write "<body onLoad=~document.getElementById('JACLCommandPrompt').focus(); jaclOfferVoice(); jaclInitMic(); jaclRenderGoogleAuth();~>^"
 write "<div id=~header~>"
 ifstring title_image = "none"
   write "<h1 name=~title~>" game_title "</h1>"
@@ -495,6 +548,8 @@ write " | "
 hyperlink "Restart" "restart" "header"
 write " | "
 hyperlink "Hint" "hint" "header"
+write " | "
+write "<span id=~jaclAuthSlot~ style=~display:inline-block; vertical-align:middle;~></span>"
 write " |"
 write "</div>^"
 write "</div>^"

--- a/projects/include/webinterface.library
+++ b/projects/include/webinterface.library
@@ -243,22 +243,28 @@ print:
     * window.JACL_GOOGLE_CLIENT_ID only when fcgijacl has both a^
     * client_id and a session_secret configured, so the button is^
     * only ever rendered on properly-set-up servers. */^
+   /* JACL's preprocessor strips leading whitespace and JACL's loader^
+    * treats a leading '.' as the print-block terminator, so Promise^
+    * chains have to keep '.then'/'.catch' off column 0 -- written^
+    * here as `var p = fetch(...); p = p.then(...);` rather than the^
+    * usual fluent chain. Likewise multi-line object literals are^
+    * inlined so no continuation line can start with '{' or '}'. */^
    function jaclGoogleCallback(response) {^
       var token = response && response.credential;^
       if (!token) return;^
       var body = 'auth=google&credential=' + encodeURIComponent(token);^
-      fetch(window.location.pathname + '?' + body, { credentials: 'same-origin' })^
-        .then(function(r) { return r.json(); })^
-        .then(function(j) {^
-           if (j && j.ok) window.location.reload();^
-        })^
-        .catch(function() {});^
+      var url = window.location.pathname + '?' + body;^
+      var p = fetch(url, { credentials: 'same-origin' });^
+      p = p.then(function(r) { return r.json(); });^
+      p = p.then(function(j) { if (j && j.ok) window.location.reload(); });^
+      p.catch(function() {});^
    }^
 
    function jaclLogout() {^
-      fetch(window.location.pathname + '?auth=logout', { credentials: 'same-origin' })^
-        .then(function() { window.location.reload(); })^
-        .catch(function() {});^
+      var url = window.location.pathname + '?auth=logout';^
+      var p = fetch(url, { credentials: 'same-origin' });^
+      p = p.then(function() { window.location.reload(); });^
+      p.catch(function() {});^
    }^
 
    function jaclRenderGoogleAuth() {^
@@ -266,25 +272,17 @@ print:
       var slot = document.getElementById('jaclAuthSlot');^
       if (!slot) return;^
       if (window.JACL_GOOGLE_SIGNED_IN) {^
-         slot.innerHTML = 'Signed in &middot; ' +^
-            '<a href="javascript:jaclLogout()">log out</a>';^
+         slot.innerHTML = 'Signed in &middot; <a href="javascript:jaclLogout()">log out</a>';^
          return;^
       }^
       if (!window.google || !google.accounts || !google.accounts.id) {^
-         /* GIS client not loaded yet -- retry once it arrives. */^
          setTimeout(jaclRenderGoogleAuth, 200);^
          return;^
       }^
-      google.accounts.id.initialize({^
-         client_id: window.JACL_GOOGLE_CLIENT_ID,^
-         callback: jaclGoogleCallback,^
-         auto_select: false^
-      });^
+      google.accounts.id.initialize({ client_id: window.JACL_GOOGLE_CLIENT_ID, callback: jaclGoogleCallback, auto_select: false });^
       slot.innerHTML = '<div id="jaclGoogleBtn"></div>';^
-      google.accounts.id.renderButton(^
-         document.getElementById('jaclGoogleBtn'),^
-         { theme: 'outline', size: 'medium', type: 'standard' }^
-      );^
+      var btn = document.getElementById('jaclGoogleBtn');^
+      google.accounts.id.renderButton(btn, { theme: 'outline', size: 'medium', type: 'standard' });^
    }^
 
    function changeInterface() {^

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -12,6 +12,9 @@ NCURSES_CFLAGS = @NCURSES_CFLAGS@
 NCURSES_LIBS = @NCURSES_LIBS@
 FCGI_CFLAGS = @FCGI_CFLAGS@
 FCGI_LIBS = @FCGI_LIBS@
+AUTH_CFLAGS = @AUTH_CFLAGS@
+AUTH_LIBS = @AUTH_LIBS@
+AUTH_SRC = @AUTH_SRC@
 
 # Source files
 COMMON_SRC = @COMMON_SRC@
@@ -31,11 +34,11 @@ jacl: libglkterm.a
 
 # Cgijacl target (CGI web)
 cgijacl: libcgihtml.a webjacl.o
-	$(CC) $(CFLAGS) -DWEBJACL cgijacl.c $(COMMON_SRC) saver.c webjacl.o -I$(CGIHTML_DIR) -Iwebjacl -L$(CGIHTML_DIR) -lcgihtml -lm -o cgijacl
+	$(CC) $(CFLAGS) $(AUTH_CFLAGS) -DWEBJACL cgijacl.c $(AUTH_SRC) $(COMMON_SRC) saver.c webjacl.o -I$(CGIHTML_DIR) -Iwebjacl -L$(CGIHTML_DIR) -lcgihtml $(AUTH_LIBS) -lm -o cgijacl
 
 # Fcgijacl target (FastCGI web, requires libfcgi)
 fcgijacl: libcgihtml.a
-	$(CC) $(CFLAGS) -DFCGIJACL cgijacl.c $(COMMON_SRC) saver.c -I$(CGIHTML_DIR) -L$(CGIHTML_DIR) -lcgihtml $(FCGI_CFLAGS) $(FCGI_LIBS) -lm -o fcgijacl
+	$(CC) $(CFLAGS) $(AUTH_CFLAGS) -DFCGIJACL cgijacl.c $(AUTH_SRC) $(COMMON_SRC) saver.c -I$(CGIHTML_DIR) -L$(CGIHTML_DIR) -lcgihtml $(FCGI_CFLAGS) $(FCGI_LIBS) $(AUTH_LIBS) -lm -o fcgijacl
 
 # webjacl.o target
 webjacl.o: webjacl.c webjacl.h language.h
@@ -76,6 +79,8 @@ apache: install
 	else \
 		echo "mod_fcgid already enabled."; \
 	fi
+	@echo "Ensuring optional Google Sign-In dependencies are available..."
+	@apt-get install -y libcurl4-openssl-dev libjansson-dev libssl-dev 2>&1 | tail -3 || true
 	@mkdir -p /usr/local/jacl/fcgi-bin
 	@echo "Creating wrapper scripts..."
 	@cp ../projects/*.jacl /usr/local/jacl/projects/ 2>/dev/null || true

--- a/src/auth.c
+++ b/src/auth.c
@@ -1,0 +1,603 @@
+/* auth.c --- Google Sign-In implementation for fcgijacl.
+ *
+ * Pure C, depends on libcurl + jansson + OpenSSL. Verifies Google ID
+ * tokens against the live JWKS at oauth2.googleapis.com and signs
+ * its own session cookie so the rest of the codebase can just read
+ * the resolved sub.
+ *
+ * Threading: fcgijacl is single-process / single-thread per request
+ * (mod_fcgid spawns multiple workers but each runs sequentially).
+ * The JWKS cache is therefore plain globals -- if you ever switch to
+ * a threaded server, wrap it in a mutex.
+ */
+
+#include "auth.h"
+
+/* Pin the OpenSSL API to the 1.1 surface so RSA_new/RSA_set0_key/
+ * RSA_free are not flagged as deprecated under OpenSSL 3. The 3.x
+ * replacement (EVP_PKEY_fromdata + OSSL_PARAMs) is verbose and the
+ * legacy path is still fully supported. */
+#ifndef OPENSSL_API_COMPAT
+#define OPENSSL_API_COMPAT 0x10100000L
+#endif
+#define OPENSSL_SUPPRESS_DEPRECATED 1
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <curl/curl.h>
+#include <jansson.h>
+#include <openssl/bn.h>
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rsa.h>
+#include <openssl/sha.h>
+
+#define GOOGLE_JWKS_URL    "https://www.googleapis.com/oauth2/v3/certs"
+#define GOOGLE_ISSUER_1    "https://accounts.google.com"
+#define GOOGLE_ISSUER_2    "accounts.google.com"
+#define JWKS_CACHE_TTL     3600          /* refresh hourly anyway */
+#define JWKS_MAX_KEYS      8
+#define MAX_TOKEN_BYTES    8192
+
+/* ---------- Configuration -------------------------------------- */
+
+static char  cfg_client_id[256]       = "";
+static char  cfg_session_secret[256]  = "";
+static long  cfg_session_max_age      = 30L * 24L * 3600L; /* 30 days */
+
+void
+auth_configure(const char *google_client_id,
+               const char *session_secret,
+               long session_max_age_seconds)
+{
+    if (google_client_id != NULL) {
+        strncpy(cfg_client_id, google_client_id, sizeof(cfg_client_id) - 1);
+        cfg_client_id[sizeof(cfg_client_id) - 1] = 0;
+    } else {
+        cfg_client_id[0] = 0;
+    }
+    if (session_secret != NULL) {
+        strncpy(cfg_session_secret, session_secret, sizeof(cfg_session_secret) - 1);
+        cfg_session_secret[sizeof(cfg_session_secret) - 1] = 0;
+    } else {
+        cfg_session_secret[0] = 0;
+    }
+    if (session_max_age_seconds > 0) {
+        cfg_session_max_age = session_max_age_seconds;
+    }
+}
+
+int
+auth_is_enabled(void)
+{
+    return cfg_client_id[0] != 0 && cfg_session_secret[0] != 0;
+}
+
+const char *
+auth_google_client_id(void)
+{
+    return cfg_client_id;
+}
+
+long
+auth_session_max_age(void)
+{
+    return cfg_session_max_age;
+}
+
+/* ---------- Base64url ------------------------------------------ */
+
+/* RFC 7515 base64url decode -- '+' '/' '=' replaced by '-' '_' and
+ * padding stripped. Writes raw bytes to out, returns length or -1. */
+static int
+b64url_decode(const char *in, size_t in_len,
+              unsigned char *out, size_t out_size)
+{
+    static const int tbl[256] = {
+        ['A']= 0,['B']= 1,['C']= 2,['D']= 3,['E']= 4,['F']= 5,['G']= 6,
+        ['H']= 7,['I']= 8,['J']= 9,['K']=10,['L']=11,['M']=12,['N']=13,
+        ['O']=14,['P']=15,['Q']=16,['R']=17,['S']=18,['T']=19,['U']=20,
+        ['V']=21,['W']=22,['X']=23,['Y']=24,['Z']=25,
+        ['a']=26,['b']=27,['c']=28,['d']=29,['e']=30,['f']=31,['g']=32,
+        ['h']=33,['i']=34,['j']=35,['k']=36,['l']=37,['m']=38,['n']=39,
+        ['o']=40,['p']=41,['q']=42,['r']=43,['s']=44,['t']=45,['u']=46,
+        ['v']=47,['w']=48,['x']=49,['y']=50,['z']=51,
+        ['0']=52,['1']=53,['2']=54,['3']=55,['4']=56,['5']=57,['6']=58,
+        ['7']=59,['8']=60,['9']=61,
+        ['-']=62,['_']=63,
+    };
+    /* Sentinel for "not in alphabet" (zero is 'A'); use 0xFF table */
+    unsigned char alphabet[256];
+    size_t i;
+    int v[4];
+    int outlen = 0;
+    int padded;
+    size_t len = in_len;
+
+    for (i = 0; i < 256; i++) alphabet[i] = 0xFF;
+    for (i = 0; i < 256; i++) {
+        if (tbl[i] != 0 || i == 'A') alphabet[i] = (unsigned char) tbl[i];
+    }
+
+    /* Strip stray '=' padding if present. */
+    while (len > 0 && in[len - 1] == '=') len--;
+
+    for (i = 0; i + 3 < len; i += 4) {
+        v[0] = alphabet[(unsigned char) in[i+0]];
+        v[1] = alphabet[(unsigned char) in[i+1]];
+        v[2] = alphabet[(unsigned char) in[i+2]];
+        v[3] = alphabet[(unsigned char) in[i+3]];
+        if (v[0] == 0xFF || v[1] == 0xFF || v[2] == 0xFF || v[3] == 0xFF) return -1;
+        if ((size_t)(outlen + 3) > out_size) return -1;
+        out[outlen++] = (unsigned char) ((v[0] << 2) | (v[1] >> 4));
+        out[outlen++] = (unsigned char) ((v[1] << 4) | (v[2] >> 2));
+        out[outlen++] = (unsigned char) ((v[2] << 6) | v[3]);
+    }
+    padded = (int) (len - i);
+    if (padded == 2) {
+        v[0] = alphabet[(unsigned char) in[i+0]];
+        v[1] = alphabet[(unsigned char) in[i+1]];
+        if (v[0] == 0xFF || v[1] == 0xFF) return -1;
+        if ((size_t)(outlen + 1) > out_size) return -1;
+        out[outlen++] = (unsigned char) ((v[0] << 2) | (v[1] >> 4));
+    } else if (padded == 3) {
+        v[0] = alphabet[(unsigned char) in[i+0]];
+        v[1] = alphabet[(unsigned char) in[i+1]];
+        v[2] = alphabet[(unsigned char) in[i+2]];
+        if (v[0] == 0xFF || v[1] == 0xFF || v[2] == 0xFF) return -1;
+        if ((size_t)(outlen + 2) > out_size) return -1;
+        out[outlen++] = (unsigned char) ((v[0] << 2) | (v[1] >> 4));
+        out[outlen++] = (unsigned char) ((v[1] << 4) | (v[2] >> 2));
+    } else if (padded != 0) {
+        return -1;
+    }
+    return outlen;
+}
+
+/* ---------- JWKS fetch + cache --------------------------------- */
+
+struct jwk_entry {
+    char         kid[128];
+    EVP_PKEY    *pkey;
+};
+
+static struct jwk_entry jwks_cache[JWKS_MAX_KEYS];
+static int    jwks_cache_count = 0;
+static time_t jwks_cache_ts    = 0;
+
+struct curl_buffer {
+    char  *data;
+    size_t len;
+    size_t cap;
+};
+
+static size_t
+curl_write_cb(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+    struct curl_buffer *buf = (struct curl_buffer *) userdata;
+    size_t n = size * nmemb;
+    if (buf->len + n + 1 > buf->cap) {
+        size_t new_cap = buf->cap ? buf->cap * 2 : 4096;
+        while (new_cap < buf->len + n + 1) new_cap *= 2;
+        char *p = (char *) realloc(buf->data, new_cap);
+        if (p == NULL) return 0;
+        buf->data = p;
+        buf->cap = new_cap;
+    }
+    memcpy(buf->data + buf->len, ptr, n);
+    buf->len += n;
+    buf->data[buf->len] = 0;
+    return n;
+}
+
+/* Build an EVP_PKEY for an RS256 verifier from base64url(n) and
+ * base64url(e). Returns NULL on failure. */
+static EVP_PKEY *
+rsa_pkey_from_jwk(const char *n_b64, const char *e_b64)
+{
+    unsigned char n_buf[1024];
+    unsigned char e_buf[16];
+    int n_len = b64url_decode(n_b64, strlen(n_b64), n_buf, sizeof(n_buf));
+    int e_len = b64url_decode(e_b64, strlen(e_b64), e_buf, sizeof(e_buf));
+    if (n_len <= 0 || e_len <= 0) return NULL;
+
+    BIGNUM *n_bn = BN_bin2bn(n_buf, n_len, NULL);
+    BIGNUM *e_bn = BN_bin2bn(e_buf, e_len, NULL);
+    if (n_bn == NULL || e_bn == NULL) {
+        if (n_bn) BN_free(n_bn);
+        if (e_bn) BN_free(e_bn);
+        return NULL;
+    }
+
+    /* OpenSSL >= 3 deprecated RSA_set0_key in favor of OSSL_PARAM/EVP
+     * builders. Use the legacy path via low-level RSA for portability;
+     * with -DOPENSSL_API_COMPAT=10100 it still compiles cleanly. */
+    RSA *rsa = RSA_new();
+    if (rsa == NULL) {
+        BN_free(n_bn);
+        BN_free(e_bn);
+        return NULL;
+    }
+    if (RSA_set0_key(rsa, n_bn, e_bn, NULL) != 1) {
+        BN_free(n_bn);
+        BN_free(e_bn);
+        RSA_free(rsa);
+        return NULL;
+    }
+    /* RSA_set0_key takes ownership of the BIGNUMs on success. */
+
+    EVP_PKEY *pkey = EVP_PKEY_new();
+    if (pkey == NULL || EVP_PKEY_assign_RSA(pkey, rsa) != 1) {
+        if (pkey) EVP_PKEY_free(pkey);
+        else RSA_free(rsa);
+        return NULL;
+    }
+    /* EVP_PKEY_assign_RSA takes ownership of rsa on success. */
+    return pkey;
+}
+
+static void
+jwks_cache_clear(void)
+{
+    int i;
+    for (i = 0; i < jwks_cache_count; i++) {
+        if (jwks_cache[i].pkey) EVP_PKEY_free(jwks_cache[i].pkey);
+        jwks_cache[i].pkey = NULL;
+        jwks_cache[i].kid[0] = 0;
+    }
+    jwks_cache_count = 0;
+}
+
+/* Fetch Google's JWKS and rebuild the cache. Returns 0 on success. */
+static int
+jwks_fetch(void)
+{
+    CURL *curl = curl_easy_init();
+    struct curl_buffer buf = { NULL, 0, 0 };
+    int rc = -1;
+    if (curl == NULL) return -1;
+
+    curl_easy_setopt(curl, CURLOPT_URL, GOOGLE_JWKS_URL);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &buf);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, 10L);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "fcgijacl/1.0");
+
+    if (curl_easy_perform(curl) != CURLE_OK) goto out;
+
+    json_error_t jerr;
+    json_t *root = json_loads(buf.data, 0, &jerr);
+    if (root == NULL) goto out;
+    json_t *keys = json_object_get(root, "keys");
+    if (!json_is_array(keys)) {
+        json_decref(root);
+        goto out;
+    }
+
+    jwks_cache_clear();
+    size_t i;
+    size_t n = json_array_size(keys);
+    if (n > JWKS_MAX_KEYS) n = JWKS_MAX_KEYS;
+    for (i = 0; i < n; i++) {
+        json_t *k = json_array_get(keys, i);
+        const char *kty = json_string_value(json_object_get(k, "kty"));
+        const char *alg = json_string_value(json_object_get(k, "alg"));
+        const char *kid = json_string_value(json_object_get(k, "kid"));
+        const char *n_s = json_string_value(json_object_get(k, "n"));
+        const char *e_s = json_string_value(json_object_get(k, "e"));
+        if (kty == NULL || strcmp(kty, "RSA") != 0) continue;
+        if (alg != NULL && strcmp(alg, "RS256") != 0) continue;
+        if (kid == NULL || n_s == NULL || e_s == NULL) continue;
+
+        EVP_PKEY *pkey = rsa_pkey_from_jwk(n_s, e_s);
+        if (pkey == NULL) continue;
+
+        strncpy(jwks_cache[jwks_cache_count].kid, kid,
+                sizeof(jwks_cache[0].kid) - 1);
+        jwks_cache[jwks_cache_count].kid[sizeof(jwks_cache[0].kid) - 1] = 0;
+        jwks_cache[jwks_cache_count].pkey = pkey;
+        jwks_cache_count++;
+    }
+    json_decref(root);
+    jwks_cache_ts = time(NULL);
+    rc = jwks_cache_count > 0 ? 0 : -1;
+
+out:
+    free(buf.data);
+    curl_easy_cleanup(curl);
+    return rc;
+}
+
+static EVP_PKEY *
+jwks_lookup(const char *kid)
+{
+    int i;
+    for (i = 0; i < jwks_cache_count; i++) {
+        if (strcmp(jwks_cache[i].kid, kid) == 0) return jwks_cache[i].pkey;
+    }
+    return NULL;
+}
+
+/* ---------- ID token verify ------------------------------------ */
+
+/* Split "header.payload.signature" into three views into a mutable
+ * copy of the input. Returns 0 on success. */
+static int
+jwt_split(char *token, char **h, char **p, char **s)
+{
+    char *dot1 = strchr(token, '.');
+    if (dot1 == NULL) return -1;
+    char *dot2 = strchr(dot1 + 1, '.');
+    if (dot2 == NULL) return -1;
+    *dot1 = 0;
+    *dot2 = 0;
+    *h = token;
+    *p = dot1 + 1;
+    *s = dot2 + 1;
+    return 0;
+}
+
+static int
+verify_signature(EVP_PKEY *pkey,
+                 const char *signing_input, size_t signing_input_len,
+                 const unsigned char *sig, size_t sig_len)
+{
+    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
+    int rc = -1;
+    if (ctx == NULL) return -1;
+    if (EVP_DigestVerifyInit(ctx, NULL, EVP_sha256(), NULL, pkey) != 1) goto out;
+    if (EVP_DigestVerifyUpdate(ctx, signing_input, signing_input_len) != 1) goto out;
+    if (EVP_DigestVerifyFinal(ctx, sig, sig_len) == 1) rc = 0;
+out:
+    EVP_MD_CTX_free(ctx);
+    return rc;
+}
+
+int
+auth_verify_id_token(const char *id_token,
+                     char *sub_out, size_t sub_size,
+                     char *err_out, size_t err_size)
+{
+    char buf[MAX_TOKEN_BYTES];
+    char *h, *p, *s;
+    int rc = -1;
+
+    if (!auth_is_enabled()) {
+        if (err_out) snprintf(err_out, err_size, "auth disabled");
+        return -1;
+    }
+    if (id_token == NULL || strlen(id_token) >= sizeof(buf)) {
+        if (err_out) snprintf(err_out, err_size, "token too long");
+        return -1;
+    }
+    strcpy(buf, id_token);
+
+    if (jwt_split(buf, &h, &p, &s) != 0) {
+        if (err_out) snprintf(err_out, err_size, "malformed JWT");
+        return -1;
+    }
+
+    /* The signed input is "header.payload" in the *original* token. */
+    char signing_input[MAX_TOKEN_BYTES];
+    snprintf(signing_input, sizeof(signing_input), "%s.%s", h, p);
+    size_t signing_input_len = strlen(signing_input);
+
+    /* Decode header to find kid + alg. */
+    unsigned char header_buf[1024];
+    int header_len = b64url_decode(h, strlen(h), header_buf, sizeof(header_buf) - 1);
+    if (header_len <= 0) {
+        if (err_out) snprintf(err_out, err_size, "bad header b64");
+        return -1;
+    }
+    header_buf[header_len] = 0;
+
+    json_error_t jerr;
+    json_t *header = json_loads((const char *) header_buf, 0, &jerr);
+    if (header == NULL) {
+        if (err_out) snprintf(err_out, err_size, "bad header json");
+        return -1;
+    }
+    const char *alg = json_string_value(json_object_get(header, "alg"));
+    const char *kid = json_string_value(json_object_get(header, "kid"));
+    if (alg == NULL || strcmp(alg, "RS256") != 0 || kid == NULL) {
+        json_decref(header);
+        if (err_out) snprintf(err_out, err_size, "alg/kid missing");
+        return -1;
+    }
+    char kid_local[128];
+    strncpy(kid_local, kid, sizeof(kid_local) - 1);
+    kid_local[sizeof(kid_local) - 1] = 0;
+    json_decref(header);
+
+    /* Decode signature. */
+    unsigned char sig_buf[512];
+    int sig_len = b64url_decode(s, strlen(s), sig_buf, sizeof(sig_buf));
+    if (sig_len <= 0) {
+        if (err_out) snprintf(err_out, err_size, "bad sig b64");
+        return -1;
+    }
+
+    /* Find the signing key, refreshing JWKS once if it's a miss or
+     * stale. */
+    EVP_PKEY *pkey = jwks_lookup(kid_local);
+    time_t now = time(NULL);
+    if (pkey == NULL || (now - jwks_cache_ts) > JWKS_CACHE_TTL) {
+        jwks_fetch();
+        pkey = jwks_lookup(kid_local);
+    }
+    if (pkey == NULL) {
+        if (err_out) snprintf(err_out, err_size, "kid not in JWKS");
+        return -1;
+    }
+
+    if (verify_signature(pkey, signing_input, signing_input_len,
+                         sig_buf, sig_len) != 0) {
+        if (err_out) snprintf(err_out, err_size, "bad signature");
+        return -1;
+    }
+
+    /* Decode payload, validate iss / aud / exp / sub. */
+    unsigned char payload_buf[4096];
+    int payload_len = b64url_decode(p, strlen(p), payload_buf,
+                                    sizeof(payload_buf) - 1);
+    if (payload_len <= 0) {
+        if (err_out) snprintf(err_out, err_size, "bad payload b64");
+        return -1;
+    }
+    payload_buf[payload_len] = 0;
+
+    json_t *payload = json_loads((const char *) payload_buf, 0, &jerr);
+    if (payload == NULL) {
+        if (err_out) snprintf(err_out, err_size, "bad payload json");
+        return -1;
+    }
+
+    const char *iss = json_string_value(json_object_get(payload, "iss"));
+    const char *aud = json_string_value(json_object_get(payload, "aud"));
+    const char *sub = json_string_value(json_object_get(payload, "sub"));
+    json_int_t exp = json_integer_value(json_object_get(payload, "exp"));
+    json_int_t iat = json_integer_value(json_object_get(payload, "iat"));
+
+    if (iss == NULL ||
+        (strcmp(iss, GOOGLE_ISSUER_1) != 0 && strcmp(iss, GOOGLE_ISSUER_2) != 0)) {
+        if (err_out) snprintf(err_out, err_size, "bad issuer");
+        json_decref(payload);
+        return -1;
+    }
+    if (aud == NULL || strcmp(aud, cfg_client_id) != 0) {
+        if (err_out) snprintf(err_out, err_size, "audience mismatch");
+        json_decref(payload);
+        return -1;
+    }
+    if (exp == 0 || (json_int_t) now >= exp) {
+        if (err_out) snprintf(err_out, err_size, "token expired");
+        json_decref(payload);
+        return -1;
+    }
+    /* 5 minutes of clock skew tolerance for iat. */
+    if (iat != 0 && iat > (json_int_t)(now + 300)) {
+        if (err_out) snprintf(err_out, err_size, "token from future");
+        json_decref(payload);
+        return -1;
+    }
+    if (sub == NULL || strlen(sub) == 0 || strlen(sub) >= sub_size) {
+        if (err_out) snprintf(err_out, err_size, "missing sub");
+        json_decref(payload);
+        return -1;
+    }
+    strcpy(sub_out, sub);
+    rc = 0;
+    json_decref(payload);
+    return rc;
+}
+
+/* ---------- Session cookie sign / verify ----------------------- */
+
+static void
+hex_encode(const unsigned char *bytes, size_t len, char *out)
+{
+    static const char *hex = "0123456789abcdef";
+    size_t i;
+    for (i = 0; i < len; i++) {
+        out[i * 2] = hex[(bytes[i] >> 4) & 0xF];
+        out[i * 2 + 1] = hex[bytes[i] & 0xF];
+    }
+    out[len * 2] = 0;
+}
+
+static int
+hex_decode(const char *in, unsigned char *out, size_t out_size)
+{
+    size_t len = strlen(in);
+    size_t i;
+    if (len % 2 != 0 || len / 2 > out_size) return -1;
+    for (i = 0; i < len; i += 2) {
+        unsigned int hi, lo;
+        char c1 = in[i], c2 = in[i + 1];
+        if (c1 >= '0' && c1 <= '9') hi = c1 - '0';
+        else if (c1 >= 'a' && c1 <= 'f') hi = c1 - 'a' + 10;
+        else if (c1 >= 'A' && c1 <= 'F') hi = c1 - 'A' + 10;
+        else return -1;
+        if (c2 >= '0' && c2 <= '9') lo = c2 - '0';
+        else if (c2 >= 'a' && c2 <= 'f') lo = c2 - 'a' + 10;
+        else if (c2 >= 'A' && c2 <= 'F') lo = c2 - 'A' + 10;
+        else return -1;
+        out[i / 2] = (unsigned char) ((hi << 4) | lo);
+    }
+    return (int) (len / 2);
+}
+
+static void
+hmac_sha256(const char *secret, const char *data, unsigned char *out)
+{
+    unsigned int outlen = 0;
+    HMAC(EVP_sha256(),
+         (const unsigned char *) secret, (int) strlen(secret),
+         (const unsigned char *) data, strlen(data),
+         out, &outlen);
+}
+
+int
+auth_make_session_cookie(const char *sub,
+                         char *cookie_out, size_t cookie_size)
+{
+    if (!auth_is_enabled() || sub == NULL) return -1;
+    long expiry = (long) time(NULL) + cfg_session_max_age;
+    char body[AUTH_SUB_MAX + 32];
+    int n = snprintf(body, sizeof(body), "%s.%ld", sub, expiry);
+    if (n < 0 || (size_t) n >= sizeof(body)) return -1;
+    unsigned char mac[32];
+    char mac_hex[65];
+    hmac_sha256(cfg_session_secret, body, mac);
+    hex_encode(mac, sizeof(mac), mac_hex);
+    n = snprintf(cookie_out, cookie_size, "%s.%s", body, mac_hex);
+    if (n < 0 || (size_t) n >= cookie_size) return -1;
+    return 0;
+}
+
+int
+auth_verify_session_cookie(const char *cookie,
+                           char *sub_out, size_t sub_size)
+{
+    if (!auth_is_enabled() || cookie == NULL) return -1;
+    char buf[AUTH_COOKIE_MAX];
+    if (strlen(cookie) >= sizeof(buf)) return -1;
+    strcpy(buf, cookie);
+
+    /* Cookie is "<sub>.<expiry>.<hex_hmac>". Split from the right
+     * since sub may itself contain digits but won't contain '.'. */
+    char *last = strrchr(buf, '.');
+    if (last == NULL) return -1;
+    *last = 0;
+    const char *mac_hex = last + 1;
+    /* "<sub>.<expiry>" remains; we don't need to split it further to
+     * verify the MAC, just to read expiry. */
+    char *body = buf;
+    char *mid = strrchr(body, '.');
+    if (mid == NULL) return -1;
+    char *expiry_str = mid + 1;
+    long expiry = strtol(expiry_str, NULL, 10);
+    if (expiry <= (long) time(NULL)) return -1;
+
+    unsigned char expected[32];
+    unsigned char given[32];
+    hmac_sha256(cfg_session_secret, body, expected);
+    if (hex_decode(mac_hex, given, sizeof(given)) != 32) return -1;
+
+    /* Constant-time compare. */
+    unsigned char diff = 0;
+    int i;
+    for (i = 0; i < 32; i++) diff |= expected[i] ^ given[i];
+    if (diff != 0) return -1;
+
+    /* Now the sub claim is everything before the last '.' in body. */
+    *mid = 0;
+    if (strlen(body) >= sub_size) return -1;
+    strcpy(sub_out, body);
+    return 0;
+}

--- a/src/auth.h
+++ b/src/auth.h
@@ -1,0 +1,61 @@
+/* auth.h --- Optional Google Sign-In for fcgijacl.
+ *
+ * Verifies Google ID tokens (RS256, JWKS at oauth2.googleapis.com)
+ * and issues an HMAC-signed session cookie that fcgijacl reads to
+ * resolve a stable user_id of the form "google_<sub>". When auth is
+ * not configured, every entry point degrades to a no-op so the
+ * existing anonymous flow is unaffected.
+ */
+
+#ifndef JACL_AUTH_H
+#define JACL_AUTH_H
+
+#include <stddef.h>
+
+/* Maximum length of a Google subject claim. Google sub values are
+ * 21-digit decimals today; we leave room for future growth. */
+#define AUTH_SUB_MAX 64
+
+/* Maximum length of the signed session cookie value. The cookie is
+ * "<sub>.<expiry>.<hex_hmac>" so 64 + 1 + 20 + 1 + 64 + slack. */
+#define AUTH_COOKIE_MAX 256
+
+/* Configure the auth module. May be called multiple times (e.g. on
+ * config reload). Both arguments are copied; pass NULL/empty to
+ * disable. session_secret should be at least 32 bytes of entropy. */
+void auth_configure(const char *google_client_id,
+                    const char *session_secret,
+                    long session_max_age_seconds);
+
+/* Returns non-zero if auth_configure has been called with both a
+ * client_id and a session_secret. Callers use this to decide whether
+ * to render the Sign-In button or the auth callback path. */
+int auth_is_enabled(void);
+
+/* Accessor for the configured Google OAuth client_id. Returns an
+ * empty string when auth is disabled, never NULL. */
+const char *auth_google_client_id(void);
+
+/* Verify a Google ID token (the credential string from GIS). On
+ * success writes the sub claim to sub_out and returns 0. On any
+ * failure (signature, claim, expiry, audience) writes a short reason
+ * to err_out (may be NULL) and returns -1. */
+int auth_verify_id_token(const char *id_token,
+                         char *sub_out, size_t sub_size,
+                         char *err_out, size_t err_size);
+
+/* Build a session-cookie value binding the given sub for the
+ * configured max age. Returns 0 on success. */
+int auth_make_session_cookie(const char *sub,
+                             char *cookie_out, size_t cookie_size);
+
+/* Verify a session-cookie value previously built by
+ * auth_make_session_cookie. On success writes the sub to sub_out and
+ * returns 0. Returns -1 on bad signature or expired cookie. */
+int auth_verify_session_cookie(const char *cookie,
+                               char *sub_out, size_t sub_size);
+
+/* Configured cookie max-age in seconds (default 2592000 = 30 days). */
+long auth_session_max_age(void);
+
+#endif /* JACL_AUTH_H */

--- a/src/auth_stub.c
+++ b/src/auth_stub.c
@@ -1,0 +1,67 @@
+/* auth_stub.c --- No-op stub used when fcgijacl is built without
+ * libcurl / jansson / openssl. Every auth_* entry point reports
+ * "auth disabled" so cgijacl falls through to the anonymous flow.
+ */
+
+#include "auth.h"
+#include <string.h>
+
+void
+auth_configure(const char *google_client_id,
+               const char *session_secret,
+               long session_max_age_seconds)
+{
+    (void) google_client_id;
+    (void) session_secret;
+    (void) session_max_age_seconds;
+}
+
+int
+auth_is_enabled(void)
+{
+    return 0;
+}
+
+const char *
+auth_google_client_id(void)
+{
+    return "";
+}
+
+long
+auth_session_max_age(void)
+{
+    return 0;
+}
+
+int
+auth_verify_id_token(const char *id_token,
+                     char *sub_out, size_t sub_size,
+                     char *err_out, size_t err_size)
+{
+    (void) id_token;
+    if (sub_out && sub_size > 0) sub_out[0] = 0;
+    if (err_out && err_size > 0) {
+        strncpy(err_out, "auth not built in", err_size - 1);
+        err_out[err_size - 1] = 0;
+    }
+    return -1;
+}
+
+int
+auth_make_session_cookie(const char *sub,
+                         char *cookie_out, size_t cookie_size)
+{
+    (void) sub;
+    if (cookie_out && cookie_size > 0) cookie_out[0] = 0;
+    return -1;
+}
+
+int
+auth_verify_session_cookie(const char *cookie,
+                           char *sub_out, size_t sub_size)
+{
+    (void) cookie;
+    if (sub_out && sub_size > 0) sub_out[0] = 0;
+    return -1;
+}

--- a/src/cgijacl.c
+++ b/src/cgijacl.c
@@ -482,11 +482,16 @@ main(int argc, char *argv[])
                                          err, sizeof(err)) == 0 &&
                     auth_make_session_cookie(sub, pending_session_cookie,
                                              sizeof(pending_session_cookie)) == 0) {
+                    const char *https_env = getenv("HTTPS");
+                    const char *secure_flag =
+                        (https_env != NULL && !strcasecmp(https_env, "on"))
+                        ? " Secure;" : "";
                     printf("Status: 200 OK\r\n");
                     printf("Content-type: application/json\r\n");
-                    printf("Set-Cookie: jacl_session=%s; Path=/; HttpOnly; "
+                    printf("Set-Cookie: jacl_session=%s; Path=/; HttpOnly;%s "
                            "SameSite=Lax; Max-Age=%ld\r\n",
-                           pending_session_cookie, auth_session_max_age());
+                           pending_session_cookie, secure_flag,
+                           auth_session_max_age());
                     printf("\r\n{\"ok\":true,\"sub\":\"%s\"}\n", sub);
                 } else {
                     sprintf(error_buffer,
@@ -500,10 +505,14 @@ main(int argc, char *argv[])
                 list_clear(&entries);
                 continue;
             } else if (!strcmp(auth_action, "logout")) {
+                const char *https_env = getenv("HTTPS");
+                const char *secure_flag =
+                    (https_env != NULL && !strcasecmp(https_env, "on"))
+                    ? " Secure;" : "";
                 printf("Status: 200 OK\r\n");
                 printf("Content-type: application/json\r\n");
-                printf("Set-Cookie: jacl_session=; Path=/; HttpOnly; "
-                       "SameSite=Lax; Max-Age=0\r\n");
+                printf("Set-Cookie: jacl_session=; Path=/; HttpOnly;%s "
+                       "SameSite=Lax; Max-Age=0\r\n", secure_flag);
                 printf("\r\n{\"ok\":true}\n");
                 list_clear(&entries);
                 continue;

--- a/src/cgijacl.c
+++ b/src/cgijacl.c
@@ -27,6 +27,7 @@
 #include "interpreter.h"
 #include "parser.h"
 #include "encapsulate.h"
+#include "auth.h"
 #include <dirent.h>
 
 extern int            style_index;
@@ -111,6 +112,23 @@ int             start_of_this_command;
 
 int             prefer_remote_user = TRUE;
 int             cookie_read_successfully;
+
+/* Optional Google Sign-In configuration. Read from cgijacl.conf and
+ * passed to auth_configure() once the file has been parsed. Empty
+ * client_id or session_secret => auth disabled, anonymous flow only. */
+char            google_client_id_cfg[256] = "\0";
+char            session_secret_cfg[256] = "\0";
+long            session_max_age_cfg = 30L * 24L * 3600L;
+
+/* Set when auth_verify_session_cookie / auth_verify_id_token resolves
+ * the request to a Google account. Used to gate Set-Cookie issuance
+ * and to seed user_id for save-file resolution. */
+char            google_sub[AUTH_SUB_MAX] = "\0";
+
+/* Pending Set-Cookie value after a successful ?auth=google callback,
+ * written out alongside the normal response headers further below. */
+char            pending_session_cookie[AUTH_COOKIE_MAX] = "\0";
+int             pending_clear_session_cookie = FALSE;
 
 int             buffer_index = 0;
 
@@ -440,10 +458,73 @@ main(int argc, char *argv[])
 
         user_id[0] = (char) 0;             // CLEAR THE USER_ID
         rpc_function_name[0] = (char) 0;    // CLEAR THE RPC FUNCTION NAME
+        google_sub[0] = (char) 0;
+        pending_session_cookie[0] = (char) 0;
+        pending_clear_session_cookie = FALSE;
 
         read_cgi_input(&entries);
         parse_cookies(&jacl_cookies);
         cookie_read_successfully = FALSE;
+
+        /* ?auth=google&credential=<id_token> -- frontend posts the
+         * Google ID token here after the GIS button callback fires.
+         * Verify it, build a signed session cookie, and short-circuit
+         * the response with a tiny JSON body so the frontend can
+         * reload and pick up the cookie. */
+        if (auth_is_enabled() && cgi_val(entries, "auth") != NULL) {
+            const char *auth_action = cgi_val(entries, "auth");
+            if (!strcmp(auth_action, "google")) {
+                const char *credential = cgi_val(entries, "credential");
+                char sub[AUTH_SUB_MAX];
+                char err[128];
+                if (credential != NULL &&
+                    auth_verify_id_token(credential, sub, sizeof(sub),
+                                         err, sizeof(err)) == 0 &&
+                    auth_make_session_cookie(sub, pending_session_cookie,
+                                             sizeof(pending_session_cookie)) == 0) {
+                    printf("Status: 200 OK\r\n");
+                    printf("Content-type: application/json\r\n");
+                    printf("Set-Cookie: jacl_session=%s; Path=/; HttpOnly; "
+                           "SameSite=Lax; Max-Age=%ld\r\n",
+                           pending_session_cookie, auth_session_max_age());
+                    printf("\r\n{\"ok\":true,\"sub\":\"%s\"}\n", sub);
+                } else {
+                    sprintf(error_buffer,
+                            "Google ID token verify failed: %s",
+                            credential ? err : "no credential");
+                    log_error(error_buffer, LOG_ONLY);
+                    printf("Status: 401 Unauthorized\r\n");
+                    printf("Content-type: application/json\r\n\r\n");
+                    printf("{\"ok\":false}\n");
+                }
+                list_clear(&entries);
+                continue;
+            } else if (!strcmp(auth_action, "logout")) {
+                printf("Status: 200 OK\r\n");
+                printf("Content-type: application/json\r\n");
+                printf("Set-Cookie: jacl_session=; Path=/; HttpOnly; "
+                       "SameSite=Lax; Max-Age=0\r\n");
+                printf("\r\n{\"ok\":true}\n");
+                list_clear(&entries);
+                continue;
+            }
+        }
+
+        /* If a valid jacl_session cookie is present, the user_id for
+         * this request is "google_<sub>". Falls through to the
+         * existing anonymous flow on missing/invalid cookie so guests
+         * still work. */
+        if (auth_is_enabled()) {
+            const char *session = cgi_val(jacl_cookies, "jacl_session");
+            if (session != NULL &&
+                auth_verify_session_cookie(session, google_sub,
+                                           sizeof(google_sub)) == 0) {
+                snprintf(user_id, sizeof(user_id), "google_%s", google_sub);
+                cookie_read_successfully = TRUE;
+                returning_player = TRUE;
+                REMOTE_USER_USED->value = TRUE;
+            }
+        }
 
         //sprintf (error_buffer, "HTTP_COOKIE: %s", getenv("HTTP_COOKIE"));
         //log_message(error_buffer, PLUS_STDERR);
@@ -451,7 +532,12 @@ main(int argc, char *argv[])
         //sprintf (error_buffer, "user_id value pulled from cookies: %s", cgi_val(jacl_cookies, "user_id"));
         //log_message(error_buffer, PLUS_STDERR);
 
-        if (cgi_val(entries, "user_id") != NULL || cgi_val(jacl_cookies, "user_id") != NULL) {
+        if (google_sub[0] != 0) {
+            /* user_id already resolved from jacl_session above; the
+             * existing user_id-cookie / parameter / REMOTE_USER /
+             * generate-random fallback chain is skipped so a Google
+             * sign-in always wins over a stale anonymous cookie. */
+        } else if (cgi_val(entries, "user_id") != NULL || cgi_val(jacl_cookies, "user_id") != NULL) {
             // A user_id HAS BEEN PASSED TO THIS REQUEST VIA A PARMETER OR A COOKIE
             if (prefer_remote_user == TRUE && REMOTE_USER != NULL && strcmp("", REMOTE_USER)) {
                 /* PREFER REMOTE_USER FOR POTENTIAL SECURE SITES. */
@@ -526,7 +612,31 @@ main(int argc, char *argv[])
 
         }
 
-        /* COPY THE VALUE OF ANY DEFINED PARAMETERS FROM THE HTTP 
+        /* Surface the auth state to game code. google_client_id is
+         * populated even on anonymous requests so the front-end can
+         * still render the Sign-In button; google_signed_in /
+         * google_sub are zeroed unless this request is bound to a
+         * verified Google session. */
+        {
+            struct string_type *cid = cstring_resolve("google_client_id");
+            struct string_type *sub_str = cstring_resolve("google_sub");
+            struct cinteger_type *signed_in = cinteger_resolve("google_signed_in");
+            if (cid != NULL) {
+                strncpy(cid->value, auth_google_client_id(),
+                        sizeof(cid->value) - 1);
+                cid->value[sizeof(cid->value) - 1] = 0;
+            }
+            if (sub_str != NULL) {
+                strncpy(sub_str->value, google_sub,
+                        sizeof(sub_str->value) - 1);
+                sub_str->value[sizeof(sub_str->value) - 1] = 0;
+            }
+            if (signed_in != NULL) {
+                signed_in->value = google_sub[0] != 0;
+            }
+        }
+
+        /* COPY THE VALUE OF ANY DEFINED PARAMETERS FROM THE HTTP
          * PARAMETERS INTO THE SPECIFIED JACL INTEGER ELEMENTS */
         update_parameters();
 
@@ -1135,12 +1245,32 @@ read_config_file()
             if (word[1] != NULL) {
                 strncpy(cookie_expiry, word[1], 80);
             }
+        } else if (!strcmp(word[0], "google_client_id")) {
+            if (word[1] != NULL) {
+                strncpy(google_client_id_cfg, word[1],
+                        sizeof(google_client_id_cfg) - 1);
+                google_client_id_cfg[sizeof(google_client_id_cfg) - 1] = 0;
+            }
+        } else if (!strcmp(word[0], "session_secret")) {
+            if (word[1] != NULL) {
+                strncpy(session_secret_cfg, word[1],
+                        sizeof(session_secret_cfg) - 1);
+                session_secret_cfg[sizeof(session_secret_cfg) - 1] = 0;
+            }
+        } else if (!strcmp(word[0], "session_max_age")) {
+            if (word[1] != NULL) {
+                session_max_age_cfg = strtol(word[1], NULL, 10);
+            }
         }
         fgets(text_buffer, 80, file);
     }
 
     fclose(file);
     file = NULL;
+
+    auth_configure(google_client_id_cfg,
+                   session_secret_cfg,
+                   session_max_age_cfg);
 }
 
 void

--- a/src/configure
+++ b/src/configure
@@ -597,12 +597,15 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 INSTALL_CMDS
 BUILD_TARGETS
+AUTH_SRC
+AUTH_LIBS
+AUTH_CFLAGS
+HAVE_PKG_CONFIG
 FCGI_LIBS
 FCGI_CFLAGS
 NCURSES_LIBS
 NCURSES_CFLAGS
 COMMON_SRC
-CHEAPGLK_DIR
 GLKTERM_DIR
 CGIHTML_DIR
 AR
@@ -1284,7 +1287,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-language=LANG    set interpreter language: english (default), french,
-                          german, indonesian
+                          german, indonesian, spanish
 
 Some influential environment variables:
   CC          C compiler command
@@ -3581,6 +3584,37 @@ if test "x$USER_CFLAGS_SET" = "x"; then
     CFLAGS="-Wall -O2"
 fi
 
+# Suppress warnings that are false positives or from third-party code.
+# These flags are gcc-specific so check before adding them.
+for wflag in -Wno-unused-result -Wno-stringop-truncation -Wno-unused-but-set-variable; do
+    save_CFLAGS="$CFLAGS"
+    CFLAGS="$CFLAGS $wflag"
+    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking whether $CC supports $wflag" >&5
+printf %s "checking whether $CC supports $wflag... " >&6; }
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main (void)
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"
+then :
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf '%s\n' "yes" >&6; }
+else case e in #(
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }; CFLAGS="$save_CFLAGS" ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+done
+
 # -----------------------------------------------------------
 # Language selection
 # -----------------------------------------------------------
@@ -3600,39 +3634,17 @@ case "$jacl_language" in
     german)      LANGUAGE_FLAG="-DNATIVE_LANGUAGE=2" ;;
     french)      LANGUAGE_FLAG="-DNATIVE_LANGUAGE=3" ;;
     indonesian)  LANGUAGE_FLAG="-DNATIVE_LANGUAGE=4" ;;
-    *)  as_fn_error $? "unknown language \"$jacl_language\" (choose: english, french, german, indonesian)" "$LINENO" 5 ;;
+    spanish)     LANGUAGE_FLAG="-DNATIVE_LANGUAGE=5" ;;
+    *)  as_fn_error $? "unknown language \"$jacl_language\" (choose: english, french, german, indonesian, spanish)" "$LINENO" 5 ;;
 esac
 
 CFLAGS="$CFLAGS $LANGUAGE_FLAG"
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: interpreter language: $jacl_language" >&5
 printf '%s\n' "$as_me: interpreter language: $jacl_language" >&6;}
 
-# Suppress warnings that are false positives or from third-party code.
-# These flags are gcc-specific so check before adding them.
-for wflag in -Wno-unused-result -Wno-stringop-truncation -Wno-unused-but-set-variable; do
-    save_CFLAGS="$CFLAGS"
-    CFLAGS="$CFLAGS $wflag"
-    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking whether $CC supports $wflag" >&5
-printf %s "checking whether $CC supports $wflag... " >&6; }
-    cat > conftest.c <<_ACEOF
-int main(void) { return 0; }
-_ACEOF
-    if $CC $CFLAGS -Werror conftest.c -o conftest >/dev/null 2>&1; then
-        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf '%s\n' "yes" >&6; }
-    else
-        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf '%s\n' "no" >&6; }
-        CFLAGS="$save_CFLAGS"
-    fi
-    rm -f conftest.c conftest
-done
-
 # Directories for bundled libraries
 CGIHTML_DIR=cgihtml-1.69
 GLKTERM_DIR=glkterm
-
-
 
 
 
@@ -3643,7 +3655,6 @@ COMMON_SRC="findroute.c interpreter.c loader.c logging.c parser.c display.c util
 # -----------------------------------------------------------
 # Check for math library (always required)
 # -----------------------------------------------------------
-
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for library containing floor" >&5
 printf %s "checking for library containing floor... " >&6; }
 if test ${ac_cv_search_floor+y}
@@ -3814,14 +3825,14 @@ fi
 
 # -----------------------------------------------------------
 # Check for libfcgi (needed for fcgijacl)
-# Check that we can both #include <fcgi_stdio.h> and link against
-# -lfcgi. On Debian/Ubuntu the libfcgi-dev headers live in
-# /usr/include/fastcgi/, not /usr/include/.
 # -----------------------------------------------------------
 FCGI_CFLAGS=""
 FCGI_LIBS=""
 HAVE_FCGI=no
 
+# Try common include and lib path combinations. On Debian/Ubuntu the
+# headers from libfcgi-dev are installed to /usr/include/fastcgi/
+# rather than /usr/include/.
 for fcgi_inc in /opt/homebrew/include /usr/local/include /usr/include/fastcgi /usr/include ""; do
     for fcgi_lib in /opt/homebrew/lib /usr/local/lib ""; do
         if test -n "$fcgi_inc"; then
@@ -3835,30 +3846,45 @@ for fcgi_inc in /opt/homebrew/include /usr/local/include /usr/include/fastcgi /u
             test_ldflags=""
         fi
 
-        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for fcgi_stdio.h and libfcgi ($test_cflags $test_ldflags)" >&5
-printf %s "checking for fcgi_stdio.h and libfcgi ($test_cflags $test_ldflags)... " >&6; }
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+        CFLAGS="$CFLAGS $test_cflags"
+        LDFLAGS="$LDFLAGS $test_ldflags"
 
-        cat > conftest.$ac_ext <<_ACEOF
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for fcgi_stdio.h and libfcgi in ($test_cflags $test_ldflags)" >&5
+printf %s "checking for fcgi_stdio.h and libfcgi in ($test_cflags $test_ldflags)... " >&6; }
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
 #include <fcgi_stdio.h>
-int main(void) { FCGI_Accept(); return 0; }
+int
+main (void)
+{
+FCGI_Accept();
+  ;
+  return 0;
+}
 _ACEOF
-
-        if $CC $CFLAGS $test_cflags conftest.$ac_ext $test_ldflags -lfcgi -o conftest$ac_exeext >/dev/null 2>&1; then
-            HAVE_FCGI=yes
-            FCGI_CFLAGS="$test_cflags"
-            if test -n "$test_ldflags"; then
-                FCGI_LIBS="$test_ldflags -lfcgi"
-            else
-                FCGI_LIBS="-lfcgi"
-            fi
-            { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+if ac_fn_c_try_link "$LINENO"
+then :
+  HAVE_FCGI=yes
+             { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 printf '%s\n' "yes" >&6; }
-        else
-            { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf '%s\n' "no" >&6; }
-        fi
+             FCGI_CFLAGS="$test_cflags"
+             if test -n "$test_ldflags"; then
+                 FCGI_LIBS="$test_ldflags -lfcgi"
+             else
+                 FCGI_LIBS="-lfcgi"
+             fi
+else case e in #(
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; } ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
 
-        rm -f conftest.$ac_ext conftest$ac_exeext conftest.o
+        CFLAGS="$save_CFLAGS"
+        LDFLAGS="$save_LDFLAGS"
 
         if test "$HAVE_FCGI" = "yes"; then
             break
@@ -3878,8 +3904,124 @@ printf '%s\n' "$as_me: libfcgi found -- will build fcgijacl" >&6;}
 else
     { printf '%s\n' "$as_me:${as_lineno-$LINENO}: WARNING: libfcgi not found -- fcgijacl will not be built" >&5
 printf '%s\n' "$as_me: WARNING: libfcgi not found -- fcgijacl will not be built" >&2;}
-    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: WARNING: On Debian/Ubuntu install with: sudo apt install libfcgi-dev" >&5
-printf '%s\n' "$as_me: WARNING: On Debian/Ubuntu install with: sudo apt install libfcgi-dev" >&2;}
+fi
+
+# -----------------------------------------------------------
+# Optional Google Sign-In dependencies for fcgijacl / cgijacl.
+# Requires libcurl + jansson + openssl. Without all three present
+# fcgijacl still builds, but auth_stub.c provides no-op auth_*
+# entry points and the anonymous flow is the only one available.
+# -----------------------------------------------------------
+AUTH_CFLAGS=""
+AUTH_LIBS=""
+AUTH_SRC="auth_stub.c"
+HAVE_GOOGLE_AUTH=no
+
+# Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+printf %s "checking for $ac_word... " >&6; }
+if test ${ac_cv_prog_HAVE_PKG_CONFIG+y}
+then :
+  printf %s "(cached) " >&6
+else case e in #(
+  e) if test -n "$HAVE_PKG_CONFIG"; then
+  ac_cv_prog_HAVE_PKG_CONFIG="$HAVE_PKG_CONFIG" # Let the user override the test.
+else
+as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  case $as_dir in #(((
+    '') as_dir=./ ;;
+    */) ;;
+    *) as_dir=$as_dir/ ;;
+  esac
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+    ac_cv_prog_HAVE_PKG_CONFIG="yes"
+    printf '%s\n' "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_prog_HAVE_PKG_CONFIG" && ac_cv_prog_HAVE_PKG_CONFIG="no"
+fi ;;
+esac
+fi
+HAVE_PKG_CONFIG=$ac_cv_prog_HAVE_PKG_CONFIG
+if test -n "$HAVE_PKG_CONFIG"; then
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $HAVE_PKG_CONFIG" >&5
+printf '%s\n' "$HAVE_PKG_CONFIG" >&6; }
+else
+  { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; }
+fi
+
+
+if test "$HAVE_PKG_CONFIG" = "yes"; then
+    if pkg-config --exists libcurl jansson openssl 2>/dev/null; then
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+        AUTH_CFLAGS=`pkg-config --cflags libcurl jansson openssl`
+        AUTH_LIBS=`pkg-config --libs   libcurl jansson openssl`
+        CFLAGS="$CFLAGS $AUTH_CFLAGS"
+        LDFLAGS="$LDFLAGS $AUTH_LIBS"
+        { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking whether auth.c builds against libcurl/jansson/openssl" >&5
+printf %s "checking whether auth.c builds against libcurl/jansson/openssl... " >&6; }
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+            #include <curl/curl.h>
+            #include <jansson.h>
+            #include <openssl/evp.h>
+            #include <openssl/hmac.h>
+
+int
+main (void)
+{
+
+            curl_easy_init(); json_loads("",0,0); EVP_sha256();
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  HAVE_GOOGLE_AUTH=yes; AUTH_SRC="auth.c"; { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+printf '%s\n' "yes" >&6; }
+else case e in #(
+  e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
+printf '%s\n' "no" >&6; } ;;
+esac
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+        CFLAGS="$save_CFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+    fi
+fi
+
+if test "$HAVE_GOOGLE_AUTH" != "yes"; then
+    AUTH_CFLAGS=""
+    AUTH_LIBS=""
+fi
+
+
+
+
+
+if test "$HAVE_GOOGLE_AUTH" = "yes"; then
+    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: libcurl + jansson + openssl found -- Google Sign-In enabled in fcgijacl" >&5
+printf '%s\n' "$as_me: libcurl + jansson + openssl found -- Google Sign-In enabled in fcgijacl" >&6;}
+else
+    { printf '%s\n' "$as_me:${as_lineno-$LINENO}: Google Sign-In disabled (need libcurl, jansson, openssl)" >&5
+printf '%s\n' "$as_me: Google Sign-In disabled (need libcurl, jansson, openssl)" >&6;}
+    { printf '%s\n' "$as_me:${as_lineno-$LINENO}:   Debian/Ubuntu: sudo apt install libcurl4-openssl-dev libjansson-dev libssl-dev" >&5
+printf '%s\n' "$as_me:   Debian/Ubuntu: sudo apt install libcurl4-openssl-dev libjansson-dev libssl-dev" >&6;}
 fi
 
 # -----------------------------------------------------------

--- a/src/configure
+++ b/src/configure
@@ -3585,10 +3585,13 @@ if test "x$USER_CFLAGS_SET" = "x"; then
 fi
 
 # Suppress warnings that are false positives or from third-party code.
-# These flags are gcc-specific so check before adding them.
+# These flags are gcc-specific so check before adding them. The test
+# uses -Werror so clang's "unknown warning option" notice -- which is
+# only a warning by default and would slip past AC_COMPILE_IFELSE --
+# becomes a hard failure and we drop the unsupported flag.
 for wflag in -Wno-unused-result -Wno-stringop-truncation -Wno-unused-but-set-variable; do
     save_CFLAGS="$CFLAGS"
-    CFLAGS="$CFLAGS $wflag"
+    CFLAGS="$CFLAGS $wflag -Werror"
     { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking whether $CC supports $wflag" >&5
 printf %s "checking whether $CC supports $wflag... " >&6; }
 
@@ -3606,7 +3609,7 @@ _ACEOF
 if ac_fn_c_try_compile "$LINENO"
 then :
   { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf '%s\n' "yes" >&6; }
+printf '%s\n' "yes" >&6; }; CFLAGS="$save_CFLAGS $wflag"
 else case e in #(
   e) { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: no" >&5
 printf '%s\n' "no" >&6; }; CFLAGS="$save_CFLAGS" ;;

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -169,6 +169,58 @@ else
 fi
 
 # -----------------------------------------------------------
+# Optional Google Sign-In dependencies for fcgijacl / cgijacl.
+# Requires libcurl + jansson + openssl. Without all three present
+# fcgijacl still builds, but auth_stub.c provides no-op auth_*
+# entry points and the anonymous flow is the only one available.
+# -----------------------------------------------------------
+AUTH_CFLAGS=""
+AUTH_LIBS=""
+AUTH_SRC="auth_stub.c"
+HAVE_GOOGLE_AUTH=no
+
+AC_CHECK_PROG([HAVE_PKG_CONFIG], [pkg-config], [yes], [no])
+if test "$HAVE_PKG_CONFIG" = "yes"; then
+    if pkg-config --exists libcurl jansson openssl 2>/dev/null; then
+        save_CFLAGS="$CFLAGS"
+        save_LDFLAGS="$LDFLAGS"
+        AUTH_CFLAGS=`pkg-config --cflags libcurl jansson openssl`
+        AUTH_LIBS=`pkg-config --libs   libcurl jansson openssl`
+        CFLAGS="$CFLAGS $AUTH_CFLAGS"
+        LDFLAGS="$LDFLAGS $AUTH_LIBS"
+        AC_MSG_CHECKING([whether auth.c builds against libcurl/jansson/openssl])
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+            #include <curl/curl.h>
+            #include <jansson.h>
+            #include <openssl/evp.h>
+            #include <openssl/hmac.h>
+        ]], [[
+            curl_easy_init(); json_loads("",0,0); EVP_sha256();
+        ]])],
+        [HAVE_GOOGLE_AUTH=yes; AUTH_SRC="auth.c"; AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+        CFLAGS="$save_CFLAGS"
+        LDFLAGS="$save_LDFLAGS"
+    fi
+fi
+
+if test "$HAVE_GOOGLE_AUTH" != "yes"; then
+    AUTH_CFLAGS=""
+    AUTH_LIBS=""
+fi
+
+AC_SUBST([AUTH_CFLAGS])
+AC_SUBST([AUTH_LIBS])
+AC_SUBST([AUTH_SRC])
+
+if test "$HAVE_GOOGLE_AUTH" = "yes"; then
+    AC_MSG_NOTICE([libcurl + jansson + openssl found -- Google Sign-In enabled in fcgijacl])
+else
+    AC_MSG_NOTICE([Google Sign-In disabled (need libcurl, jansson, openssl)])
+    AC_MSG_NOTICE([  Debian/Ubuntu: sudo apt install libcurl4-openssl-dev libjansson-dev libssl-dev])
+fi
+
+# -----------------------------------------------------------
 # Build the target list
 # -----------------------------------------------------------
 BUILD_TARGETS="bjorb cgijacl"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -12,13 +12,16 @@ if test "x$USER_CFLAGS_SET" = "x"; then
 fi
 
 # Suppress warnings that are false positives or from third-party code.
-# These flags are gcc-specific so check before adding them.
+# These flags are gcc-specific so check before adding them. The test
+# uses -Werror so clang's "unknown warning option" notice -- which is
+# only a warning by default and would slip past AC_COMPILE_IFELSE --
+# becomes a hard failure and we drop the unsupported flag.
 for wflag in -Wno-unused-result -Wno-stringop-truncation -Wno-unused-but-set-variable; do
     save_CFLAGS="$CFLAGS"
-    CFLAGS="$CFLAGS $wflag"
+    CFLAGS="$CFLAGS $wflag -Werror"
     AC_MSG_CHECKING([whether $CC supports $wflag])
     AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
-        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([yes]); CFLAGS="$save_CFLAGS $wflag"],
         [AC_MSG_RESULT([no]); CFLAGS="$save_CFLAGS"])
 done
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -153,6 +153,14 @@ read_gamefile()
     create_cinteger ("GLK", 0);
     create_cinteger ("CGI", 1);
     create_cinteger ("NDS", 2);
+
+    /* Optional Google Sign-In state. cgijacl writes these on each
+     * request before parsing user commands; on GLK / console builds
+     * they stay at their defaults so games can branch on them
+     * without ifdefs. */
+    create_cinteger ("google_signed_in", 0);
+    create_cstring  ("google_sub", "");
+    create_cstring  ("google_client_id", "");
 #ifdef GLK
     create_cinteger ("interpreter", 0);
 #else


### PR DESCRIPTION
## Summary
- Adds an opt-in Google Sign-In flow to `fcgijacl` (and `cgijacl`) so returning players can resume saves keyed off their Google `sub`. Anonymous play is untouched when auth isn't configured.
- New `src/auth.{h,c}` module verifies Google ID tokens (RS256, live JWKS via libcurl + jansson + OpenSSL), and signs an HMAC-SHA256 session cookie in pure C with no third-party JWT library.
- `src/auth_stub.c` provides no-op implementations for builds where libcurl/jansson/openssl aren't available, so fcgijacl still links and Sign-In is silently disabled.

## What it does

- **No config = no change.** When `google_client_id` is empty, no auth-related JS is emitted, no cookie is read, and `user_id` resolution follows the existing anonymous path.
- **With config**, the header gets a Google Identity Services button. On click the GIS callback POSTs the ID token to `?auth=google&credential=<jwt>`. fcgijacl verifies it (issuer, audience, exp, signature against cached JWKS) and returns `Set-Cookie: jacl_session=<sub>.<expiry>.<hex_hmac>; HttpOnly; SameSite=Lax`. On every subsequent request `user_id` becomes `google_<sub>` so save files key off the stable Google subject.
- `?auth=logout` clears the cookie.
- Three new JACL constants are populated on every request — `google_client_id`, `google_signed_in`, `google_sub` — so game code can branch without ifdefs.

## Setup

See `etc/google-auth-setup.md`. Two new config keys in `cgijacl.conf`:
```
google_client_id  "1234567890-abcdef.apps.googleusercontent.com"
session_secret    "<openssl rand -hex 32>"
session_max_age   2592000
```
Build deps for the apache target are installed automatically by `make apache`.

## Test plan
- [ ] `./configure && make cgijacl` builds with libcurl + jansson + openssl present (auth.c).
- [ ] Without those libs `./configure` reports `Google Sign-In disabled (...)` and fcgijacl still links via `auth_stub.c`.
- [ ] With `google_client_id` unset in `cgijacl.conf`, the rendered HTML contains no `accounts.google.com` script and the Sign-In slot is empty.
- [ ] After setting `google_client_id` + `session_secret`, the header shows the GIS button. Clicking it and completing Google auth reloads with `Signed in / log out`.
- [ ] Playing a few moves, logging out, signing back in restores the same save (`google_<sub>.auto`).
- [ ] Anonymous play in a private window still works (no jacl_session cookie, falls through to random user_id).
- [ ] Tampering with the `jacl_session` cookie (changing the sub or the HMAC) invalidates it and the request falls back to anonymous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)