### PR TITLE
cgijacl/webjacl: harden auth flow against path traversal, response splitting, and DoS

### DIFF
--- a/src/cgijacl.c
+++ b/src/cgijacl.c
@@ -59,6 +59,66 @@ newest_include_mtime(void)
     return newest;
 }
 
+/* Returns 1 if s is a safe identifier for use in a file path or
+ * HTTP header value: non-empty, ASCII [A-Za-z0-9_.-], no longer than
+ * max-1 bytes (room for NUL). Used to gate every user_id assignment so
+ * a malicious cookie/parameter can neither traverse out of
+ * temp_directory nor inject CRLF into Set-Cookie. */
+static int
+is_safe_user_id(const char *s, size_t max)
+{
+    size_t i;
+    if (s == NULL || s[0] == 0) return 0;
+    for (i = 0; s[i] != 0; i++) {
+        unsigned char c = (unsigned char) s[i];
+        if (i + 1 >= max) return 0;
+        if (!((c >= 'A' && c <= 'Z') ||
+              (c >= 'a' && c <= 'z') ||
+              (c >= '0' && c <= '9') ||
+              c == '_' || c == '-' || c == '.'))
+            return 0;
+    }
+    return 1;
+}
+
+/* Same charset as is_safe_user_id, and additionally rejects ".." to
+ * defang path-traversal attempts through save-game filenames coming
+ * from game-supplied text (text_of() in save_interaction). */
+static int
+is_safe_filename_component(const char *s, size_t max)
+{
+    if (!is_safe_user_id(s, max)) return 0;
+    if (strstr(s, "..") != NULL) return 0;
+    return 1;
+}
+
+/* Fill buf with "anon_" + 32 hex chars from /dev/urandom + NUL.
+ * Returns 0 on success, -1 on failure (caller should treat as fatal
+ * for the request rather than fall back to a guessable ID). The
+ * previous implementation used rand() seeded with time(NULL), giving
+ * ~32k entropy guessable from the request timestamp. */
+static int
+secure_random_user_id(char *buf, size_t buflen)
+{
+    /* "anon_" (5) + 32 hex + NUL = 38 */
+    if (buflen < 38) return -1;
+    FILE *fp = fopen("/dev/urandom", "rb");
+    if (fp == NULL) return -1;
+    unsigned char raw[16];
+    size_t got = fread(raw, 1, sizeof(raw), fp);
+    fclose(fp);
+    if (got != sizeof(raw)) return -1;
+    static const char hex[] = "0123456789abcdef";
+    memcpy(buf, "anon_", 5);
+    size_t i;
+    for (i = 0; i < sizeof(raw); i++) {
+        buf[5 + i * 2]     = hex[(raw[i] >> 4) & 0xF];
+        buf[5 + i * 2 + 1] = hex[raw[i] & 0xF];
+    }
+    buf[5 + sizeof(raw) * 2] = 0;
+    return 0;
+}
+
 /* Returns 1 for yes, 0 for no, -1 for invalid */
 static int
 resolve_yes_or_no(const char *input)
@@ -583,6 +643,12 @@ main(int argc, char *argv[])
         //sprintf (error_buffer, "user_id value pulled from cookies: %s", cgi_val(jacl_cookies, "user_id"));
         //log_message(error_buffer, PLUS_STDERR);
 
+        /* Every code path that assigns user_id below routes through
+         * is_safe_user_id(). The id ends up in a file path (auto-save)
+         * and an HTTP Set-Cookie header, so a value containing '/',
+         * CR/LF, or '..' would yield path traversal or response
+         * splitting. Invalid candidates fall through to fresh
+         * anonymous-id creation. */
         if (google_sub[0] != 0) {
             /* user_id already resolved from jacl_session above; the
              * existing user_id-cookie / parameter / REMOTE_USER /
@@ -590,51 +656,58 @@ main(int argc, char *argv[])
              * sign-in always wins over a stale anonymous cookie. */
         } else if (cgi_val(entries, "user_id") != NULL || cgi_val(jacl_cookies, "user_id") != NULL) {
             // A user_id HAS BEEN PASSED TO THIS REQUEST VIA A PARMETER OR A COOKIE
+            const char *candidate = NULL;
+            int from_cookie = FALSE;
             if (prefer_remote_user == TRUE && REMOTE_USER != NULL && strcmp("", REMOTE_USER)) {
                 /* PREFER REMOTE_USER FOR POTENTIAL SECURE SITES. */
-                strcpy (user_id, REMOTE_USER);
-                //sprintf(error_buffer, "Using user_id %s from REMOTE_USER.", user_id);
-                //log_message(error_buffer, PLUS_STDERR);
-                REMOTE_USER_USED->value = TRUE;
+                candidate = REMOTE_USER;
+            } else if (cgi_val(jacl_cookies, "user_id") != NULL) {
+                candidate = cgi_val(jacl_cookies, "user_id");
+                from_cookie = TRUE;
+            } else {
+                candidate = cgi_val(entries, "user_id");
+            }
+            if (is_safe_user_id(candidate, sizeof(user_id))) {
+                strcpy(user_id, candidate);
+                REMOTE_USER_USED->value = (from_cookie || candidate == REMOTE_USER) ? TRUE : FALSE;
+                cookie_read_successfully = from_cookie ? TRUE : cookie_read_successfully;
                 returning_player = TRUE;
             } else {
-                // THERE IS NO REMOTE_USER OR prefer_remote_user IS SET TO FALSE
-                // SO USE THE PASSED user_id
-                if (cgi_val(jacl_cookies, "user_id") != NULL) {
-                    strcpy(user_id, cgi_val(jacl_cookies, "user_id"));
-                    REMOTE_USER_USED->value = TRUE;
-                    cookie_read_successfully = TRUE;
-                    //sprintf(error_buffer, "Using user_id %s from cookie.", user_id);
-                    //log_message(error_buffer, PLUS_STDERR);
-                } else {
-                    strcpy(user_id, cgi_val(entries, "user_id"));
-                    REMOTE_USER_USED->value = FALSE;
-                    //sprintf(error_buffer, "Using user_id %s from parameter.", user_id);
-                    //log_message(error_buffer, PLUS_STDERR);
-                }
-                returning_player = TRUE;
+                sprintf(error_buffer,
+                        "Rejected unsafe user_id (length or charset); using a fresh anonymous id.");
+                log_error(error_buffer, LOG_ONLY);
+                /* Leave user_id untouched; the else-branch below will
+                 * generate a secure random id. */
             }
         } else if (REMOTE_USER != NULL && strcmp("", REMOTE_USER)) {
             // REMOTE_USER IS SET AND user_id IS NULL SO USE REMOTE_USER
-            strcpy (user_id, REMOTE_USER);
-            //sprintf(error_buffer, "Using user_id %s from REMOTE_USER.", user_id);
-            //log_message(error_buffer, PLUS_STDERR);
-            REMOTE_USER_USED->value = TRUE;
-            returning_player = TRUE;
-        } else {
-            // REMOTE_USER ISN'T SET AND user_id IS BLANK SO CREATE A NEW user_id
-            sprintf(user_id, "%d-%d",
-                    (1 + (int) ((float) 58408 * rand() / (RAND_MAX + 1.0))),
-                    (1 + (int) ((float) 256 * rand() / (RAND_MAX + 1.0))));
+            if (is_safe_user_id(REMOTE_USER, sizeof(user_id))) {
+                strcpy(user_id, REMOTE_USER);
+                REMOTE_USER_USED->value = TRUE;
+                returning_player = TRUE;
+            } else {
+                sprintf(error_buffer,
+                        "Rejected unsafe REMOTE_USER value; using a fresh anonymous id.");
+                log_error(error_buffer, LOG_ONLY);
+            }
+        }
+        if (google_sub[0] == 0 && user_id[0] == 0) {
+            // No usable user_id yet -- create a secure anonymous one.
+            if (secure_random_user_id(user_id, sizeof(user_id)) != 0) {
+                /* /dev/urandom unavailable -- refuse rather than fall
+                 * back to rand() which gave guessable ~32k entropy
+                 * seeded from request time. */
+                log_error("Unable to read /dev/urandom for anonymous user_id; aborting request.",
+                          PLUS_STDOUT);
+                list_clear(&entries);
+                continue;
+            }
 
             // THIS IS THE FIRST COMMAND OF A NEW GAME
             returning_player = FALSE;
 
-            //sprintf(error_buffer, "Created user_id %s for new user.", user_id);
-            //log_message(error_buffer, PLUS_STDERR);
-
             // SET THIS TO TRUE ASSUMING THAT COOKIES ARE ENABLED
-            REMOTE_USER_USED->value = TRUE; 
+            REMOTE_USER_USED->value = TRUE;
         }
 
         if (returning_player == TRUE) {
@@ -1617,7 +1690,15 @@ restore_interaction(const char *filename)
     if (filename == NULL) {
         sprintf(file_buffer, "%s%s-%s-bookmark", temp_directory, prefix, user_id);
     } else {
-        sprintf(file_buffer, "%s%s-%s-%s", temp_directory, prefix, user_id, text_of(filename));
+        const char *raw = text_of(filename);
+        /* `raw` is game-supplied (the JACL author passes a noun or a
+         * literal). Reject anything that could escape temp_directory:
+         * slashes, backslashes, "..", control chars. */
+        if (!is_safe_filename_component(raw, 81)) {
+            write_text(cstring_resolve("CANT_RESTORE")->value);
+            return (FALSE);
+        }
+        sprintf(file_buffer, "%s%s-%s-%s", temp_directory, prefix, user_id, raw);
     }
 
     if (restore_game(file_buffer, TRUE) == FALSE) {
@@ -1635,7 +1716,12 @@ save_interaction(const char *filename)
     if (filename == NULL) {
         sprintf(file_buffer, "%s%s-%s-bookmark", temp_directory, prefix, user_id);
     } else {
-        sprintf(file_buffer, "%s%s-%s-%s", temp_directory, prefix, user_id, text_of(filename));
+        const char *raw = text_of(filename);
+        if (!is_safe_filename_component(raw, 81)) {
+            write_text(cstring_resolve("CANT_SAVE")->value);
+            return (FALSE);
+        }
+        sprintf(file_buffer, "%s%s-%s-%s", temp_directory, prefix, user_id, raw);
     }
 
     if (save_game(file_buffer)) {

--- a/src/webjacl.c
+++ b/src/webjacl.c
@@ -281,7 +281,13 @@ wj_setupdb(void)
 				*terminator = 0;
 
 			if (!feof(fp)) {
-				fields = sscanf(sline, "%s %s %s", sreq, smime, spath);
+				/* Width specifiers bound each field; sline is
+				 * 6144 bytes and a single unbroken word could
+				 * otherwise overflow sreq/smime/spath. The widths
+				 * are chosen so the reassembled "%s %s %s" fits
+				 * in p->data[1024]: 255 + 1 + 127 + 1 + 511 = 895
+				 * plus NUL. */
+				fields = sscanf(sline, "%255s %127s %511s", sreq, smime, spath);
 
 				/* Test for empty line or comment */
 				if ((fields != 3) || (sreq[0] == '#'))
@@ -290,8 +296,13 @@ wj_setupdb(void)
 
 				/* Allocate space for a new element */
 				p = (struct media *) malloc(sizeof(struct media));
+				if (p == NULL) {
+					fprintf(stderr, "WebJACL: out of memory loading media list\n");
+					break;
+				}
 				oldp->next = p;
-				sprintf(p->data, "%s %s %s", sreq, smime, spath);
+				snprintf(p->data, sizeof(p->data),
+					 "%s %s %s", sreq, smime, spath);
 				p->next = NULL;
 				oldp = p;
 			}
@@ -614,11 +625,18 @@ listen_again:
 							 * match! Extract the
 							 * relevant fields
 							 */
-							sscanf(mp->data, "%s %s %s", sreq, smime, spath);
+							/* Widths bound each field. mp->data is 1024
+							 * bytes; the source widths used by wj_setupdb
+							 * (255/127/511) make these caps generous. */
+							sscanf(mp->data, "%1023s %1023s %2047s",
+							    sreq, smime, spath);
 							if (wj_script_dir[0] != '\0')
-								sprintf(fullpath, "%s/%s", wj_script_dir, spath);
-							else
-								strcpy(fullpath, spath);
+								snprintf(fullpath, sizeof(fullpath),
+									 "%s/%s", wj_script_dir, spath);
+							else {
+								strncpy(fullpath, spath, sizeof(fullpath) - 1);
+								fullpath[sizeof(fullpath) - 1] = 0;
+							}
 
 							/*
 							 * Now read in the
@@ -646,6 +664,25 @@ listen_again:
 								FILE           *media_fp;
 								char           *media_buffer;
 
+								/* Cap media reads to keep a multi-GB
+								 * file (or fd manipulation that makes
+								 * stat return a huge size) from DoSing
+								 * the server with a single request. */
+								#define WJ_MEDIA_MAX_BYTES (64L * 1024L * 1024L)
+								if (filestat.st_size < 0 ||
+								    (long) filestat.st_size > WJ_MEDIA_MAX_BYTES) {
+									printf
+										("HTTP/1.0 413 Payload Too Large\r\nServer: %s\r\nConnection: close\r\nContent-Type: text/html\r\n\r\n",
+										 WJ_SERVERNAME);
+									printf
+										("<HTML><HEAD></HEAD><BODY><H1>413 Payload Too Large</H1></BODY></HTML>\r\n");
+									fflush(stdout);
+									dup2(savefdOUT, MYSTDOUT);
+									dup2(savefdIN, MYSTDIN);
+									shutdown(clientFd, 2);
+									clientFd = -1;
+									goto listen_again;
+								}
 								if ((media_buffer =
 								     malloc(filestat.st_size + 1)) == NULL) {
 									fprintf(stderr,


### PR DESCRIPTION
## Summary

Fixes the network-exploitable HIGH findings from the recent C-code security review. Scope was chosen deliberately: this PR touches **only** `src/cgijacl.c` and `src/webjacl.c`, leaves the interpreter/parser/loader/jacl findings for follow-up PRs, and defers all design-decision items (charset policy, crypto rename, save-format asymmetry) to separate issues.

### Fixed (cgijacl.c)

- **Path traversal via user_id** (cgijacl.c:610/641/1067): a `user_id` query parameter or cookie value containing `../` flowed into the auto-save path `${temp_directory}${prefix}-${user_id}.auto` and let a request read/overwrite any file the cgijacl process could touch.
- **Response splitting via user_id** (cgijacl.c:773): the same value was echoed verbatim into a `Set-Cookie:` header; a CR/LF payload would forge additional headers.
- **Reflected XSS via user_id** (default_footer): the value also reached `<input type=hidden name="user_id" value="%s">` without escaping.
- **Path traversal via game-supplied save filename** (cgijacl.c:1620/1638): `save_interaction`/`restore_interaction` interpolated `text_of(filename)` straight into the save-file path; a `save "../../../etc/passwd"` from game code would resolve to `/etc/passwd`.
- **Predictable anonymous session IDs** (cgijacl.c:626-628): the existing generator was `sprintf(user_id, "%d-%d", rand()%58408+1, rand()%256+1)` with the PRNG seeded by `time(NULL)`, giving ~32k entropy guessable from the request timestamp — enough to load someone else's auto-save by guessing.

All five are addressed by two new validators (`is_safe_user_id` / `is_safe_filename_component`) plus a `/dev/urandom`-backed generator. The validators restrict ids and game-supplied filenames to `[A-Za-z0-9_.-]` (with an additional `..`-substring reject for filenames). Existing IDs in the format `1234-56` or `google_<digits>` remain valid; only IDs containing path/header-injection bytes are rejected. The choice of charset is **conservative-but-not-policy**: see "Deferred design items" below.

### Fixed (webjacl.c)

- **Stack overflow via `.media`** (webjacl.c:284/617): `sscanf(sline, "%s %s %s", sreq, smime, spath)` with no width spec — a single unbroken word in the manifest overflowed the fixed-size buffers. Now `%255s %127s %511s` (in wj_setupdb) and `%1023s %1023s %2047s` (when re-reading from the media list).
- **Unbounded sprintf into `p->data`** (webjacl.c:294): paired with the above; switched to `snprintf` with `sizeof(p->data)` and added a NULL-check on the `malloc` return.
- **DoS via huge media file** (webjacl.c:674): `malloc(filestat.st_size + 1)` had no upper bound. Now caps at 64 MB and returns HTTP 413 above that.

### Investigated and intentionally NOT patched

Three findings from the consolidated review were re-examined while preparing this PR and judged not exploitable. They're listed here so a future reviewer doesn't have to redo the analysis:

- **auth.c:585 (expiry-before-MAC timing oracle).** The expiry value is in the body of any captured cookie; an attacker holding such a cookie already knows the expiry. The MAC compare itself is constant-time. The timing variation between "expired → fast return" and "wrong MAC → slow return" only leaks "this token was once well-formed" — public to anyone who holds it.
- **auth.c:387 (signing_input snprintf truncation).** `signing_input` and `buf` share `MAX_TOKEN_BYTES`. After `jwt_split`, `strlen(h) + 1 + strlen(p) + 1 + strlen(s) < MAX_TOKEN_BYTES`, so `strlen(h) + 1 + strlen(p) < MAX_TOKEN_BYTES - 1` and the snprintf cannot truncate.
- **webjacl.c:584-591 (qstring overflow).** `fgets(request_line, WJ_MAX_REQ_SIZE - 1, stdin)` puts the NUL at position ≤ WJ_MAX_REQ_SIZE-2, and the subsequent `strncpy(request, request_line, WJ_MAX_REQ_SIZE - 1)` pads through to the end of the destination because strncpy NUL-fills past an early-NUL source. The output index `q` therefore stops within `qstring_copy` and the `*q = '\0'` terminator lands at most at index WJ_MAX_REQ_SIZE-7.

### Deferred design items (separate issues recommended)

These came up while writing the patch but were left out per agreed PR scope:

- [ ] Canonical anonymous-id format and migration path. This PR generates `anon_<32 hex>`; legacy `1234-56` IDs still validate and continue to work via cookie. Decide whether to actively migrate or just let old IDs age out with their cookies.
- [ ] Final user_id charset policy. Current implementation is `[A-Za-z0-9_.-]`. Tighter (no `.`, no `-`) would be safer; looser (allow `:`) would matter only if some deployment relies on it.
- [ ] `Set-Cookie: ... \n` should be `\r\n` (cgijacl.c lines 773, 593, 616, 656). Cosmetic / strict-proxy issue, separate refactor.
- [ ] XOR-with-0xFF in `decrypt.c` and `utils.c` is marketed as "encryption" — should be renamed `obfuscate_*` or replaced with a real cipher.
- [ ] `glk_saver.c` vs `saver.c` save-format asymmetry (last_command not round-tripped on Glk; call_count filter divergence).

## Test plan

- [x] `gcc -std=gnu23 -Wall -O2 ... cgijacl.c auth.c webjacl.c <COMMON_SRC>` builds clean, no warnings.
- [x] `make jacl` (non-auth target) builds clean with the shared source files unchanged.
- [x] Resulting `cgijacl` runs and emits the expected "no game file" startup banner.
- [ ] Manual: load `space.jacl` via fcgijacl, sign in via Google, confirm the resulting `user_id` is `google_<sub>` and the auto-save lands in `temp_directory`.
- [ ] Manual: log out, confirm next request creates a fresh `anon_<32 hex>` and a working auto-save.
- [ ] Manual: send a request with `?user_id=../../etc/passwd` and confirm it's rejected (server log: "Rejected unsafe user_id"; fresh anonymous id assigned instead).
- [ ] Manual: send a request with `?user_id=foo%0d%0aSet-Cookie:%20evil=1` and confirm the response has no injected `Set-Cookie:` line.
- [ ] Manual: from game code, `save "../foo"` returns CANT_SAVE and writes no file.
- [ ] Manual: place a 100 MB file in the media dir, reference it from `.media`, confirm 413 response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)