### PR TITLE
interpreter/parser/resolvers: fix semantic bugs from C review

### DIFF
--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -3397,7 +3397,7 @@ push_proxy()
             while (current_cstring != NULL);
         }
 
-        proxy_backup[proxy_stack].textcount = counter;
+        proxy_backup[proxy_stack].textcount = text;
         proxy_backup[proxy_stack].commandcount = command;
         proxy_backup[proxy_stack].after_from = after_from;
         proxy_backup[proxy_stack].last_exact = last_exact;
@@ -3862,7 +3862,14 @@ inspect (int object_num)
     } else {
         while (object_elements[index] != NULL) {
             if (index == 0) {
-                sprintf(temp_buffer, "%s: %s (%d)^", object_elements[index], object[object[object_num]->integer[index]]->label, object[object_num]->integer[index]);
+                /* PARENT slot: mirror the bounds check the LOCATION
+                 * branch above does, otherwise objects with PARENT == 0
+                 * (limbo) or a corrupt index crash on object[oob]->label. */
+                if (object[object_num]->integer[index] < 1 || object[object_num]->integer[index] > objects) {
+                    sprintf(temp_buffer, "%s: nowhere (%d)^", object_elements[index], object[object_num]->integer[index]);
+                } else {
+                    sprintf(temp_buffer, "%s: %s (%d)^", object_elements[index], object[object[object_num]->integer[index]]->label, object[object_num]->integer[index]);
+                }
             } else {
                 sprintf(temp_buffer, "%s: %d^", object_elements[index], object[object_num]->integer[index]);
             }

--- a/src/parser.c
+++ b/src/parser.c
@@ -1491,7 +1491,14 @@ noun_resolve(struct word_type *scope_word, int finding_from, int noun_number)
 				counter++;
 				current_name = current_name->next_name;
 			}
-			confidence[index] = ((confidence[index] - 1) * 100) / counter;
+			/* Guard against an object with no names (first_name == NULL):
+			 * dividing by counter would SIGFPE. Treat no-name objects as
+			 * having zero confidence so they can't win disambiguation. */
+			if (counter > 0) {
+				confidence[index] = ((confidence[index] - 1) * 100) / counter;
+			} else {
+				confidence[index] = 0;
+			}
 		}
 	}
 
@@ -1694,14 +1701,21 @@ noun_resolve(struct word_type *scope_word, int finding_from, int noun_number)
 			sentence_output(index, 0);
 			write_text(temp_buffer);
 			matches--;
-			if (counter < 9)
-				counter++;
 			write_text("^");
+			if (counter >= 9) {
+				/* Cap displayed options at 9; without breaking out of
+				 * the loop, additional iterations would overwrite
+				 * possible_objects[9] and emit duplicate "[9] ..."
+				 * lines because the prior cap stopped incrementing
+				 * `counter` but did not stop the loop. */
+				break;
+			}
+			counter++;
 		}
 	}
 
 	/* GET A NUMBER: don't insist, low = 1, high = counter */
-	selection = get_number(FALSE, 1, counter - 1);
+	selection = get_number(FALSE, 1, counter);
 
 	if (selection == -1) {
 		write_text (cstring_resolve("INVALID_SELECTION")->value);
@@ -1779,7 +1793,9 @@ scope(int index, const char *expected, int restricted)
 			 * BEING HELD. IE, A LABEL ON A JAR CAN BE SHOWN BECAUSE
 			 * THE JAR IS BEING HELD. */
             temp = object[index]->PARENT;
-			if (temp > 0 && temp < objects) {
+			/* Valid object indices are 1..objects inclusive; the prior
+			 * `temp < objects` excluded the highest-numbered object. */
+			if (temp > 0 && temp <= objects) {
 				if (object[temp]->PARENT == HELD) {
 					return (TRUE);
 				}
@@ -1811,7 +1827,8 @@ scope(int index, const char *expected, int restricted)
 	} else if (!strcmp(expected, "*anywhere") || !strcmp(expected, "**anywhere")) {
 		return (TRUE);
 	} else if (!strcmp(expected, "*inside") || !strcmp(expected, "**inside")) {
-		if (object_list[0][0] >0 && object_list[0][0] < objects) {
+		/* Valid object indices are 1..objects inclusive. */
+		if (object_list[0][0] > 0 && object_list[0][0] <= objects) {
 			return (parent_of(object_list[0][0], index, restricted));
 		} else {
 			// THERE IS NO PREVIOUS OBJECT SO TREAT THIS LIKE A *here 

--- a/src/resolvers.c
+++ b/src/resolvers.c
@@ -331,6 +331,7 @@ integer_resolve(const char *name)
 	char            expression[84];
 
 	strncpy(expression, name, 80);
+	expression[80] = 0;	/* strncpy doesn't NUL-terminate when src >= 80 chars */
 
 	counter = strlen(expression);
 
@@ -421,6 +422,7 @@ cinteger_resolve(const char *name)
 	char            expression[84];
 
 	strncpy(expression, name, 80);
+	expression[80] = 0;	/* strncpy doesn't NUL-terminate when src >= 80 chars */
 
 	counter = strlen(expression);
 
@@ -511,6 +513,7 @@ string_resolve(const char *name)
 	char            expression[84];
 
 	strncpy(expression, name, 80);
+	expression[80] = 0;	/* strncpy doesn't NUL-terminate when src >= 80 chars */
 
 	counter = strlen(expression);
 
@@ -592,6 +595,7 @@ cstring_resolve(const char *name)
 	char            expression[84];
 
 	strncpy(expression, name, 80);
+	expression[80] = 0;	/* strncpy doesn't NUL-terminate when src >= 80 chars */
 
 	counter = strlen(expression);
 
@@ -1192,13 +1196,22 @@ object_resolve(const char *object_string)
 		return (HERE);
 	else if (!strcmp(object_string, "self") ||
 			 !strcmp(object_string, "this")) {
-		if (executing_function != NULL && executing_function->self == 0) {
+		/* Three cases: no function, global function (self==0), or
+		 * method on a real object. Previously the chain dereferenced
+		 * executing_function->self even when executing_function was
+		 * NULL because the && short-circuited the first check. */
+		if (executing_function == NULL) {
+			sprintf(error_buffer,
+					"ERROR: Reference to 'self' outside any function.^");
+			write_text(error_buffer);
+		} else if (executing_function->self == 0) {
 			sprintf(error_buffer,
 					"ERROR: Reference to 'self' from global function \"%s\".^",
 					executing_function->name);
 			write_text(error_buffer);
-		} else
+		} else {
 			return (executing_function->self);
+		}
 	} else {
 		for (index = 1; index <= objects; index++) {
 			if (!strcmp(object_string, object[index]->label))


### PR DESCRIPTION
## Summary

Second follow-up PR from the C-code security/quality review. Scope: the **interpreter semantic bugs** tier — concrete logic errors and crashes in `interpreter.c`, `parser.c`, and `resolvers.c`. Network-exploitable items are already in #37; this PR is local-impact correctness.

### Fixed

**interpreter.c**
- Proxy stack `textcount` was assigned from `counter` (the integer-loop variable) instead of `text` (the string-loop variable). Any proxy call where `int count != string count` silently corrupted the saved string array on restore — restoring too few strings (data loss) or stale slots from before the push. Wrong-variable, single-character fix; potentially explains state-restoration weirdness no one had traced.
- `inspect` output dereferenced `object[object[n]->integer[0]]->label` (the PARENT slot) without bounds-checking. The mirror branch for LOCATION objects (a few lines up) does check; the object branch did not. Crash on `PARENT == 0` or corrupted index. Mirror the same check.

**parser.c**
- Divide-by-zero when an object has `first_name == NULL` (no declared synonyms). Treat as zero confidence rather than `((conf-1)*100)/0`.
- Two `< objects` off-by-ones in scope checks (`*held` heavy-parent path; `*inside`) — valid indices run `1..objects` inclusive, so the highest-numbered object was silently dropped from these scope rules.
- Disambiguation prompt: the prior 9-option cap stopped incrementing `counter` but did not break the loop, so iteration 10+ overwrote `possible_objects[9]` and emitted duplicate `"[9] ..."` lines. The `get_number` range was also off-by-one for the exact-9-candidate case (the prompt accepted 1..8 even though the display showed 1..9). Break out at 9 and widen the prompt range to `counter`.

**resolvers.c**
- `object_resolve("self"/"this")` chain dereferenced `executing_function->self` even when `executing_function` was NULL: the leading `executing_function != NULL && executing_function->self == 0` short-circuited correctly, but the bare `else` then ran `->self` regardless. Split into three explicit cases.
- Four `strncpy(expression, name, 80)` sites in `cstring_resolve`, `string_resolve`, and friends wrote into `expression[84]` without forcing a NUL when the source was ≥ 80 chars; the following `strlen(expression)` would read into stack garbage. Add `expression[80] = 0;` after each.

### Investigated and intentionally NOT patched

- **`cstring_resolve(...)->value` NULL-deref across parser.c (45 sites).** The pattern *can* return NULL in theory, but `loader.c:1620-1750+` runs 99 `if (cstring_resolve("X") == NULL) create_cstring("X", X);` fallback initialisations covering every standard cstring — including all four names the agent specifically flagged (`NO_MULTI_VERB`, `DOUBLE_EXCEPT`, `CONTAINER_CLOSED`, `CONTAINER_CLOSED_FEM`). A wholesale patch would be 45 lines of churn for no real safety gain. Belongs in a later refactor (introducing a `cstring_value()` helper across the codebase) rather than this PR.

## Test plan

- [x] `gcc -std=gnu23 -Wall -O2` build of both `jacl` (Glk) and `cgijacl` (CGI + auth) is clean — no new warnings introduced.
- [x] Smoke: `./jacl projects/space.jacl` loads and renders the status line.
- [ ] Manual: provoke a proxy-call that mixes ints and strings (e.g. via `+intro` flow) and confirm restored state is correct.
- [ ] Manual: declare an object with `inspect` in a game and run it on an object with `PARENT == 0` — should print "nowhere (0)" instead of crashing.
- [ ] Manual: declare a 10-candidate disambiguation scenario (e.g. ten brass keys) and confirm only [1]..[9] are displayed and selecting [9] returns the correct object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)