### PR TITLE
bjorb/jpp/loader: fix loader/persistence HIGHs from C review

### DIFF
--- a/src/bjorb.c
+++ b/src/bjorb.c
@@ -109,13 +109,14 @@ static void
 write_id (FILE * f, const char *s)
 /*
  * write_id writes a string to a file as a blorb ID string (4 bytes, space
- * padded)
+ * padded). Clamp at 4 chars so a stray longer string can't corrupt the
+ * IFF stream silently.
  */
 {
   int i;
   char sp = ' ';
 
-  for (i = 0; i < strlen (s); i++)
+  for (i = 0; i < 4 && s[i]; i++)
     fwrite (&s[i], 1, 1, f);
   for (; i < 4; i++)
     fwrite (&sp, 1, 1, f);
@@ -123,12 +124,13 @@ write_id (FILE * f, const char *s)
 
 static void
 str_id (char *f, const char *s)
-// str_id writes a blorb identifier to a string
+// str_id writes a blorb identifier to a string. Same 4-char clamp as
+// write_id.
 {
   int i;
   char sp = ' ';
 
-  for (i = 0; i < strlen (s); i++)
+  for (i = 0; i < 4 && s[i]; i++)
     f[i] = s[i];
   for (; i < 4; i++)
     f[i] = sp;
@@ -155,13 +157,18 @@ ReadChunk (FILE * f)
       free (N);
       return NULL;
     }
-  // Read in the rest of the line to the buffer
+  // Read in the rest of the line to the buffer. Always allocate at
+  // least one byte even if the line is empty -- the Use="1"/"3"/file
+  // branches below all write Buffer[current] = 0 and dereference it,
+  // so a NULL Buffer from an empty line would crash.
+  buflen = 16;
+  Buffer = (char *) my_malloc (buflen);
   while (1)
     {
       c = fgetc (f);
       if (c == EOF || c == '\n')
 	break;
-      if (current == buflen)
+      if (current + 1 >= buflen)
 	{
 	  buflen = (buflen + 1) * 2;
 	  Buffer = (char *) my_realloc (Buffer, buflen);
@@ -267,6 +274,13 @@ BuildIndex (FILE * f)
   // Load all the chunks
   while (!feof (f))
     {
+      if (Chunks >= MAX_BLORB)
+	{
+	  fprintf (stderr,
+		   "%s: Error: BLC file has more than %d chunks; aborting.\n",
+		   MyName, MAX_BLORB);
+	  exit (1);
+	}
       Line++;
       Blorb[Chunks] = ReadChunk (f);
       if (Blorb[Chunks])
@@ -379,15 +393,27 @@ main (int argc, char **argv)
     }
 
   if (argc == 2) {
-	/* SINGLE ARGUMENT SUPPLIED, CONSIDER IT A BASE NAME FOR THE BLC AND BLORB FILES */
-	  strcpy (InName, argv[1]);
-	  strcat (InName, ".blc");
-
-      strcpy (OutName, argv[1]);
-	  strcat (OutName, ".blorb");
+	/* SINGLE ARGUMENT SUPPLIED, CONSIDER IT A BASE NAME FOR THE BLC AND BLORB FILES.
+	 * Both buffers are 81 bytes; argv[1] up to 74 chars fits before the
+	 * ".blorb" suffix overflows. Refuse longer paths cleanly. */
+	  if (strlen (argv[1]) + 6 >= sizeof (InName)) {
+		  fprintf (stderr,
+			   "%s: Error: base name too long (max %zu chars).\n",
+			   MyName, sizeof (InName) - 7);
+		  exit (1);
+	  }
+	  snprintf (InName, sizeof (InName), "%s.blc", argv[1]);
+	  snprintf (OutName, sizeof (OutName), "%s.blorb", argv[1]);
     } else {
-	  strcpy (InName, argv[1]);
-      strcpy (OutName, argv[2]);
+	  if (strlen (argv[1]) >= sizeof (InName) ||
+	      strlen (argv[2]) >= sizeof (OutName)) {
+		  fprintf (stderr,
+			   "%s: Error: file name too long (max %zu chars).\n",
+			   MyName, sizeof (InName) - 1);
+		  exit (1);
+	  }
+	  snprintf (InName, sizeof (InName), "%s", argv[1]);
+	  snprintf (OutName, sizeof (OutName), "%s", argv[2]);
 	}
 
     in = fopen (InName, "r");

--- a/src/jpp.c
+++ b/src/jpp.c
@@ -144,6 +144,7 @@ process_file(const char *sourceFile1, const char *sourceFile2)
 
 	if (fgets(text_buffer, 1024, inputFile) == NULL) {
 		sprintf (error_buffer, READ_ERROR);
+		fclose(inputFile);
 		return (FALSE);
 	}
 
@@ -158,15 +159,22 @@ process_file(const char *sourceFile1, const char *sourceFile2)
 			includeFile = strchr(text_buffer, '"');
 
 			if (includeFile != NULL) {
-				strcpy(temp_buffer1, game_path);
-				strcat(temp_buffer1, includeFile + 1);
-				strcpy(temp_buffer2, include_directory);
-				strcat(temp_buffer2, includeFile + 1);
+				/* Bound path assembly: game_path (up to 255 chars per
+				 * cgijacl globals) plus an include name read from the
+				 * source line (up to ~1023 chars after the leading
+				 * quote) easily overflows temp_buffer1[1025] with
+				 * strcpy+strcat. snprintf truncates cleanly instead. */
+				snprintf(temp_buffer1, sizeof(temp_buffer1),
+					 "%s%s", game_path, includeFile + 1);
+				snprintf(temp_buffer2, sizeof(temp_buffer2),
+					 "%s%s", include_directory, includeFile + 1);
 				if (process_file(temp_buffer1, temp_buffer2) == FALSE) {
+					fclose(inputFile);
 					return (FALSE);
 				}
 			} else {
 				sprintf (error_buffer, BAD_INCLUDE);
+				fclose(inputFile);
 				return (FALSE);
 			}
 		} else {

--- a/src/loader.c
+++ b/src/loader.c
@@ -782,9 +782,14 @@ read_gamefile()
                         nongloberr(line);
                         errors++;
                     } else {
-                        strncpy(function_name, word[wp], 59);
-                        strcat(function_name, "_");
-                        strcat(function_name, object[object_count]->label);
+                        /* Assemble "<verb>_<label>" into function_name[81].
+                         * The previous strncpy(59)+strcat+strcat could
+                         * write up to 59+1+43+1 = 104 bytes when label
+                         * is at its declared max of 44 chars; snprintf
+                         * truncates cleanly at the buffer size. */
+                        snprintf(function_name, sizeof(function_name),
+                                 "%s_%s", word[wp],
+                                 object[object_count]->label);
                         self_parent = object_count;
                     }
                     if ((current_function->next_function =
@@ -1287,12 +1292,14 @@ restart_game()
     /* FREE ALL OBJECTS */
     for (index = 1; index <= objects; index++) {
         current_name = object[index]->first_name;
-        while (current_name->next_name != NULL) {
+        /* Guard against an object whose first_name was never set
+         * (declaration failed mid-load). The previous unguarded loop
+         * crashed on the first iteration. */
+        while (current_name != NULL) {
             next_name = current_name->next_name;
             free(current_name);
             current_name = next_name;
         }
-        free(current_name);
         free(object[index]);
     }
 


### PR DESCRIPTION
## Summary

Third follow-up PR from the C-code review. Tier: **loader/persistence HIGHs** — bugs in code that reads attacker-controlled bytes (blorb manifests, game files, includes) or builds paths from untrusted-by-default input. Three files; each fix is small and self-contained.

### bjorb.c (blorb packager)

- **`BuildIndex` writes past `Blorb[MAX_BLORB]`** — the chunk-read loop incremented `Chunks` past 1024 with no guard, overflowing the static stack array. A BLC file with > 1024 entries (or an adversarial one) corrupted whatever was adjacent. Now bails with an error before the bad write.
- **`ReadChunk` deref of NULL Buffer on empty BLC line** — the line-read loop only allocated `Buffer` on demand. If the line terminator was hit before any content (or on EOF mid-record), `Buffer` stayed NULL and three of the four downstream branches wrote `Buffer[current] = 0` and read it back. Always allocate up front.
- **`write_id` / `str_id` 4-char clamp** — the loops used `i < strlen(s)` instead of `i < 4 && s[i]`. No current caller passes a string > 4 chars, but the unguarded form would silently corrupt the IFF stream if one ever did.
- **`main` argv[1]/argv[2] → `InName[81]` / `OutName[81]`** — `strcpy(InName, argv[1]); strcat(InName, ".blc");` overflowed when `argv[1]` was ≥ 75 chars. snprintf with an explicit up-front length check; refuse over-long base names cleanly.

### jpp.c (JACL preprocessor)

- **FD leaks on three error-return paths** in `process_file` — the first-line fgets failure, recursive `process_file` failure, and `BAD_INCLUDE` paths all returned FALSE without `fclose(inputFile)`. On a chain of N failed includes, leaks N file descriptors. Now closed on each path.
- **Path-assembly overflow** at the include-resolution site — `strcpy(temp_buffer1, game_path); strcat(temp_buffer1, includeFile + 1);` could write up to ~1278 bytes into `temp_buffer1[1025]` (game_path up to 255 chars + an include name up to ~1023 chars from `text_buffer`). snprintf truncates cleanly.

### loader.c

- **`function_name[81]` overflow** during the second-pass `verb_label` assembly — `strncpy(59) + strcat("_") + strcat(label)` could write up to 59+1+43+1 = 104 bytes when `label` was at its declared 44-char max (`types.h:72`). snprintf with `sizeof(function_name)`; over-long verb+object combinations truncate to a shorter (still valid identifier-shaped) name instead of overflowing into adjacent state. Truncated names will fail the subsequent function-table lookup with a clean "function not found" error rather than corrupting memory.
- **`restart_game` NULL deref on first_name** — the free-objects loop dereferenced `current_name->next_name` without first checking `current_name != NULL`. An object whose declaration failed mid-load (no `first_name` assigned) crashed on the first iteration on restart. Rewrote the loop to terminate on NULL; equivalent freeing for non-empty lists, safe for empty ones.

### Skipped (verified false positive or out of scope)

- **bjorb.c `ftell` unchecked** → giant malloc — re-traced: ftell returns -1 on error, cast through `unsigned long` into `int my_malloc` argument is -1, `malloc(-1)` returns NULL, `my_malloc` exits cleanly. No exploitable path.
- **jpp.c predictable temp filename** at `fopen(processed_file, "w")` — would need a wider mkstemp refactor; deferred to a separate hardening PR rather than mixing into this scope.
- **loader.c `while(!feof)` + unchecked `fgets` across the file** (~12 sites) — pervasive pattern; belongs in the upcoming mechanical-safety sweep rather than this PR.

## Test plan

- [x] `gcc -std=gnu23 -Wall -O2` builds all three of `jacl`, `cgijacl`, and `bjorb` cleanly, no new warnings.
- [x] `bjorb` smoke: prints its banner and usage on `bjorb --help`-style invocation.
- [ ] Manual: run `bjorb foo` where `foo.blc` lists > 1024 chunks and confirm the "too many chunks" error instead of a corruption-shaped crash.
- [ ] Manual: feed `bjorb` a BLC file with an empty (`\n`-only) record and confirm clean failure instead of NULL deref.
- [ ] Manual: load a `.jacl` whose `#include` chain has a missing file partway through; confirm the preprocessor's open-fd count returns to baseline after the error path.
- [ ] Manual: declare a JACL function whose `<verb>_<object_label>` would total > 80 chars (e.g. very long verb + max-length object label) and confirm graceful failure instead of memory corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)