### PR TITLE
jacl/dsjacl/winglk: fix frontend HIGHs from C review

### DIFF
--- a/src/dsjacl.c
+++ b/src/dsjacl.c
@@ -315,7 +315,9 @@ main(int argc, char *argv[])
 		index = 0;
 
 		if (*current_command) {
-			while (*(current_command + index) && index < 1024) {
+			/* Cap at 1023 so the trailing terminator below lands inside
+			 * text_buffer[1024]. */
+			while (*(current_command + index) && index < 1023) {
 				if (*(current_command + index) == '\r' || *(current_command + index) == '\n') {
 					break;
 				} else {
@@ -858,11 +860,12 @@ get_character(char *message)
 }
 
 void
-get_string(char *string_buffer)
+get_string(char *string_buffer, int size)
 {
     char *cx;
 	char commandbuf[256];
 	int index;
+	int copy_cap;
 
 	jflush();
 	printf("\x1b[32;0m"); 							// SET TO DIM GREEN
@@ -880,9 +883,12 @@ get_string(char *string_buffer)
 		}
 	}
 
-	// COPY UP TO 255 BYTES OF THE ENTERED TEXT INTO THE SUPPLIED STRING
-	strncpy (string_buffer, cx, 255);
-	
+	/* Copy up to size-1 bytes; previously this strncpy'd 255 bytes
+	 * with no terminator at all if the input filled commandbuf. */
+	copy_cap = (size > 256) ? 255 : size - 1;
+	if (copy_cap < 0) copy_cap = 0;
+	strncpy (string_buffer, cx, copy_cap);
+	string_buffer[copy_cap] = 0;
 }
 
 char *

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -1221,7 +1221,7 @@ execute(const char *funcname)
 
                     // PROMPT THE USER TO INPUT A STRING AND STORE IT IN THE
                     // RESOLVED VARIABLE
-                    get_string(resolved_string->value);
+                    get_string(resolved_string->value, sizeof(resolved_string->value));
                 }
                 
             } else if (!strcmp(word[0], "asknumber") || !strcmp(word[0], "getnumber")) {
@@ -1360,7 +1360,7 @@ execute(const char *funcname)
 
                     // PROMPT THE USER TO INPUT A STRING AND STORE IT IN THE
                     // RESOLVED VARIABLE
-                    get_string(resolved_string->value);
+                    get_string(resolved_string->value, sizeof(resolved_string->value));
                 }
                 
             } else if (!strcmp(word[0], "asknumber") || !strcmp(word[0], "getnumber")) {

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -462,6 +462,16 @@ glk_main(void)
 		// THE PLAYER'S INPUT WILL BE UTF-32. CONVERT IT TO UTF-8 AND NULL TERMINATE IT
 #ifndef NOUNICODE
 		convert_to_utf8(command_buffer_uni, ev.val1);
+#else
+		/* Glk does not NUL-terminate command_buffer after a byte-mode
+		 * line event. Without this terminator the read loop below
+		 * walks past ev.val1 bytes into stale data from a previous
+		 * turn (command_buffer is a file-scope static, so its tail
+		 * holds whatever the previous input wrote there). */
+		if (ev.val1 < (int) sizeof(command_buffer))
+			command_buffer[ev.val1] = 0;
+		else
+			command_buffer[sizeof(command_buffer) - 1] = 0;
 #endif
 
 		current_command = command_buffer;
@@ -481,7 +491,9 @@ glk_main(void)
 		index = 0;
 
 		if (*current_command) {
-			while (*(current_command + index) && index < 1024) {
+			/* Cap at 1023 so the trailing `text_buffer[index] = 0;`
+			 * below lands inside the buffer; text_buffer is 1024 bytes. */
+			while (*(current_command + index) && index < 1023) {
 				if (*(current_command + index) == '\r' || *(current_command + index) == '\n') {
 					break;
 				} else {
@@ -1064,11 +1076,12 @@ get_number(int insist, int low, int high)
 }
 
 void
-get_string(char *string_buffer)
+get_string(char *string_buffer, int size)
 {
     char *cx;
 	char commandbuf[256];
     int gotline;
+    int copy_cap;
     event_t ev;
 
     status_line();
@@ -1105,9 +1118,13 @@ get_string(char *string_buffer)
     commandbuf[ev.val1] = '\0';
     for (cx = commandbuf; *cx == ' '; cx++) { };
 
-	// COPY UP TO 255 BYTES OF THE ENTERED TEXT INTO THE SUPPLIED STRING
-	strncpy (string_buffer, cx, 255);
-	string_buffer[255] = 0;
+	/* Copy up to size-1 bytes of the entered text into the caller's
+	 * buffer; the previous fixed 255+terminate-at-[255] wrote past the
+	 * end of any caller buffer smaller than 256 bytes. */
+	copy_cap = (size > 256) ? 255 : size - 1;
+	if (copy_cap < 0) copy_cap = 0;
+	strncpy (string_buffer, cx, copy_cap);
+	string_buffer[copy_cap] = 0;
 }
 
 int

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -48,7 +48,7 @@ void create_paths(char *full_path);
 int get_key(void);
 char get_character(const char *message);
 int get_yes_or_no(void);
-void get_string(char *string_buffer);
+void get_string(char *string_buffer, int size);
 int get_number(int insist, int low, int high);
 int save_interaction(const char *filename);
 int restore_interaction(const char *filename);

--- a/src/winglk_startup.c
+++ b/src/winglk_startup.c
@@ -32,16 +32,28 @@ winglk_startup_code(const char* cmdline)
 	sprintf(temp_buffer, "JACL v%d.%d.%d by Stuart Allen.", J_VERSION, J_RELEASE, J_BUILD);
 	winglk_set_about_text(temp_buffer);
 
-	/* CHECK FOR ANY COMMAND LINE ARGUMENTS AND REMOVE THEM */
+	/* CHECK FOR ANY COMMAND LINE ARGUMENTS AND REMOVE THEM.
+	 *
+	 * The previous logic had two bugs:
+	 *   1. `else if` chain meant only the first flag found was honoured;
+	 *      the second was silently dropped.
+	 *   2. `*argument = 0` truncated the entire cmdline at the start of
+	 *      the flag. A cmdline like `-noencrypt game.jacl` would lose
+	 *      the filename portion before winglk_get_initial_filename
+	 *      could see it; the user then got the file-open dialog with
+	 *      no explanation.
+	 *
+	 * Now: independent ifs so both flags are honoured, and blanking with
+	 * spaces in place so the surrounding cmdline tokens survive. */
 	if (cmdline != NULL) {
-    	if ((argument = strstr(cmdline, "-noencrypt")) != NULL) {
+		if ((argument = strstr(cmdline, "-noencrypt")) != NULL) {
 			encrypt = FALSE;
-			*argument = 0;
-        } else if ((argument = strstr(cmdline, "-release")) != NULL) {
-			release = TRUE;
-			*argument = 0;
+			memset(argument, ' ', strlen("-noencrypt"));
 		}
-
+		if ((argument = strstr(cmdline, "-release")) != NULL) {
+			release = TRUE;
+			memset(argument, ' ', strlen("-release"));
+		}
 	}
 
 	/* PROCESS THE COMMAND LINE AND GET A FILE NAME FROM THAT.


### PR DESCRIPTION
## Summary

Fourth follow-up PR from the C-code review. Tier: **frontend HIGHs** — bugs in the platform-startup and input-handling code (`jacl.c`, `dsjacl.c`, `winglk_startup.c`). Three small fixes, each independent.

### get_string API (jacl.c + dsjacl.c)

`get_string(char *string_buffer)` silently wrote up to 256 bytes (255 + terminator) into a caller-sized buffer with no length parameter. Both current callers happen to pass `resolved_string->value` (1025 bytes), so it didn't crash today, but the API was a tripwire for any new caller with a smaller buffer. Changed the signature to `get_string(char *string_buffer, int size)` and cap the strncpy + terminator inside the function. Updated both callers (`interpreter.c:1224`, `interpreter.c:1363`) and the prototype.

Note the dsjacl.c copy of `get_string` was actually *worse* than jacl.c's — its `strncpy(string_buffer, cx, 255)` had no forced NUL terminator at all, so if the input filled commandbuf to 255 chars there was no NUL in the caller's buffer. Same fix.

### Byte-mode command_buffer NUL termination (jacl.c)

Glk does not NUL-terminate after `glk_request_line_event` in byte mode. The `#ifndef NOUNICODE` path runs `convert_to_utf8`, which terminates as a side effect; the `#ifdef NOUNICODE` path had nothing. The subsequent read loop then walked past `ev.val1` bytes into whatever was in `command_buffer`'s tail — which, because `command_buffer` is a file-scope static, holds the previous turn's input. A "go" on turn 2 after "examine console" on turn 1 would be parsed as the contents of `command_buffer` until the next NUL — likely "go" followed by stale chars from "examine console" — producing garbled tokenisation.

Added an explicit `command_buffer[ev.val1] = 0;` on the byte path.

### Read-loop bound off-by-one (jacl.c + dsjacl.c)

The input-copy loop used `index < 1024` paired with a post-loop `text_buffer[index] = 0;`. If the loop hit the bound (index reached 1024), the terminator wrote one past the end of `text_buffer[1024]`. Tightened the loop bound to `index < 1023` so the terminator lands inside the buffer. Same fix in `dsjacl.c`.

### winglk_startup argv parsing

Two bugs in the cmdline flag handling:

1. The `else if` chain only honoured the first of `-noencrypt` or `-release` — the second was silently dropped. Split into two independent `if`s.
2. After locating a flag, the code did `*argument = 0;` which NUL-terminated the cmdline at the start of the flag. A cmdline like `winglk.exe -noencrypt game.jacl` therefore truncated to `winglk.exe ` — the filename was lost, and `winglk_get_initial_filename` fell back to the file-open dialog with no explanation. Replaced with `memset(argument, ' ', strlen(flag))` so the flag is blanked in place but surrounding tokens (including a following filename) survive.

## Test plan

- [x] `gcc -std=gnu23 -Wall -O2` builds both `jacl` (Glk) and `cgijacl` (CGI+auth) cleanly, no new warnings.
- [ ] Manual: build with `-DNOUNICODE` and confirm consecutive turns no longer leak each other's tail bytes into the parser.
- [ ] Manual: use `getstring`/`get_string` from a JACL game and confirm normal input still works.
- [ ] Manual (Windows-only, can't test on this Mac): `winglk.exe -noencrypt game.jacl` opens game.jacl directly without falling through to the file dialog; `winglk.exe -noencrypt -release game.jacl` honours both flags.

## Notes

- `winglk_startup.c` isn't part of the standard Mac/Linux build, so the build check ran without it. The change is straightforward C with no platform-specific dependencies beyond what was already there.
- The `get_string` signature change is technically an API break for any out-of-tree caller, but the function is interpreter-internal — no exported header outside the source tree references it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)