### PR TITLE
glk_saver: align save format with saver.c (filter nosave, persist last_command)

### DIFF
--- a/src/glk_saver.c
+++ b/src/glk_saver.c
@@ -46,7 +46,12 @@ save_game(frefid_t saveref)
 	}
 
     while (current_function != NULL) {
-		write_integer (bookmark, current_function->call_count);
+		/* Filter by nosave so the format matches saver.c (CGI). The
+		 * previous unfiltered write made glk saves silently
+		 * incompatible with CGI saves of the same game. */
+		if (current_function->nosave == FALSE) {
+			write_integer (bookmark, current_function->call_count);
+		}
         current_function = current_function->next_function;
     }
 
@@ -69,6 +74,13 @@ save_game(frefid_t saveref)
 		}
         current_string = current_string->next_string;
     }
+
+	/* Persist last_command so 'again' works after restore. saver.c
+	 * already did this; glk_saver previously dropped it, leaving
+	 * restored Glk saves with an empty or stale last-command slot. */
+	for (index = 0; index < 1024; index++) {
+		glk_put_char_stream(bookmark, last_command[index]);
+	}
 
 	write_integer (bookmark, player);
 	write_integer (bookmark, noun[3]);
@@ -137,7 +149,12 @@ restore_game(frefid_t saveref, int warn)
 	}
 
 	while (current_function != NULL) {
-		current_function->call_count = read_integer (bookmark);
+		/* Matched filter from save_game above; must agree with the
+		 * write side or the byte stream shifts by 4 bytes per
+		 * non-nosave function and the rest of the read goes haywire. */
+		if (current_function->nosave == FALSE) {
+			current_function->call_count = read_integer (bookmark);
+		}
 		current_function = current_function->next_function;
 	}
 
@@ -159,6 +176,12 @@ restore_game(frefid_t saveref, int warn)
 		}
         current_string = current_string->next_string;
     }
+
+	/* Matches the save side: pull last_command back so 'again' still
+	 * has a target after the restore. */
+	for (index = 0; index < 1024; index++) {
+		last_command[index] = glk_get_char_stream(bookmark);
+	}
 
 	player = read_integer(bookmark);
 	noun[3] = read_integer(bookmark);


### PR DESCRIPTION
## Summary

Fifth follow-up PR from the C-code review. Closes one of the deferred design items from PR #37: the save-format asymmetry between `saver.c` (CGI) and `glk_saver.c` (Glk).

## What was wrong

The two savers wrote subtly different file layouts:

| Field | saver.c (CGI) | glk_saver.c (Glk, before) |
|---|---|---|
| header counts (4 ints) | yes | yes |
| integers | yes | yes |
| function call_count | **filtered by `nosave==FALSE`** | **all functions, unconditional** |
| objects | yes | yes |
| strings | yes | yes |
| `last_command` (1024 bytes) | **yes** | **no** |
| player + noun[3] | yes | yes |
| volume[0..7] + event_timer | n/a (no audio) | yes (Glk-only) |

Two consequences:

1. **A save written by saver.c can't be loaded by glk_saver and vice versa** — the byte offsets diverge starting at the call_count block. The `validate-by-counts` header check at the top of `restore_game` does not detect the size mismatch.
2. **`again` after a Glk restore did the wrong thing.** Because `last_command` wasn't round-tripped, restoring loaded into an in-memory `last_command` that still held whatever the player typed last *before* the restore — or a stale tail from previous use. saver.c got this right; glk_saver dropped it.

## What this PR does

Aligns `glk_saver.c` with `saver.c`:

- Filters the call_count write/read by `current_function->nosave == FALSE`.
- Writes/reads a 1024-byte `last_command` block between strings and player.

Audio fields (`volume[8]` + `event_timer`) are intentionally Glk-only and stay at the end of the Glk save format.

## Format-compatibility break

**Existing `.glksave` files are not loadable by this build.** The byte layout has shifted — one call_count entry per nosave function removed, plus 1024 new bytes of last_command inserted before the player slot. There's no save-format version field to negotiate, and the validate-by-counts header check can't detect the layout shift. The incompatibility manifests as garbled state on restore.

The alternatives were worse:
- Leave the formats divergent forever → silently breaks `again` on Glk; CGI saves never cross over to the local Glk player.
- Add a version field and migrate → a meaningful design discussion that should happen on a clean slate. The current `restore_game` validation is fragile (count-only) and warrants a real format rev separately.

This is the lesser one-time break. The next save-format change should introduce a real version field as a prerequisite.

## What's NOT in this PR

Three other deferred items from the original list:

- **XOR rename** (`jacl_encrypt` → `jacl_obfuscate`): touches `decrypt.c`, `utils.c`, `prototypes.h`, AND the in-flight files `jpp.c` (PR #40), `loader.c` (PR #40), `interpreter.c` (PR #41). Blocked until those merge.
- **Mechanical-safety sweep** (`while(!feof)` → checked fgets, sprintf → snprintf, strncpy NUL terminators): the pervasive sites are in `loader.c`, `interpreter.c`, `bjorb.c`, `jpp.c`, `cgijacl.c` — all overlap with pending PRs. Blocked.
- **Anon-id active migration**: PR #37 left this passive (legacy IDs still validate via cookie). No code change is needed unless we actively want to expire old anonymous sessions. Recommending we leave passive — the existing 6-hour cookie expiry naturally ages them out, and an active migration step would have to choose between rewriting auto-save filenames (risky) or invalidating in-flight sessions (rude). Closing as "no change".

## Test plan

- [x] `gcc -std=gnu23 -Wall -O2 -DGLK ...` builds `jacl` cleanly.
- [ ] Manual: save with the new build, restore, type `again`, confirm the last command replays correctly (was previously broken on Glk).
- [ ] Manual: confirm an OLD `.glksave` from before this PR fails to restore (the validate-by-counts header probably won't reject it — symptom is garbled state on subsequent commands).
- [ ] Optional: write a save with the CGI build of the same game, attempt to restore in the Glk build (will fail because Glk save has trailing audio fields the CGI side doesn't write; the cross-frontend interop still needs explicit work, but the saver-shared portion of the file is now consistent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)