### PR TITLE
fix build warnings: webjacl format-truncation + glkterm format-overflow

### DIFF
--- a/src/webjacl.c
+++ b/src/webjacl.c
@@ -266,7 +266,10 @@ wj_setupdb(void)
 		 */
 		int             fields;
 		char           *terminator;
-		char            sreq[1024], smime[1024], spath[2048], sline[6144];
+		/* Sized to match the sscanf width specs below so the compiler
+		 * can prove the subsequent snprintf into p->data[1024] cannot
+		 * truncate. 256 + 128 + 512 + 2 separators + NUL = 899 bytes. */
+		char            sreq[256], smime[128], spath[512], sline[6144];
 
 		while (!feof(fp)) {
 			fgets(sline, sizeof(sline) - 1, fp);
@@ -615,9 +618,14 @@ listen_again:
 					//printf("%ld\n", mediadb.next);
 					for             (mp = mediadb.next; mp != NULL; mp = mp->next) {
 						if (strstr(mp->data, qstring_copy) == mp->data) {
-							char            sreq[1024],
-							                smime[1024],
-							                spath[2048], fullpath[4096];
+							/* Sized to match wj_setupdb's widths so the
+							 * compiler can prove the snprintf below
+							 * cannot truncate. fullpath bumped to 8192
+							 * to give headroom over wj_script_dir
+							 * (4096) + "/" + spath (512). */
+							char            sreq[256],
+							                smime[128],
+							                spath[512], fullpath[8192];
 							requested_item_found = 1;
 
 							/*
@@ -625,10 +633,7 @@ listen_again:
 							 * match! Extract the
 							 * relevant fields
 							 */
-							/* Widths bound each field. mp->data is 1024
-							 * bytes; the source widths used by wj_setupdb
-							 * (255/127/511) make these caps generous. */
-							sscanf(mp->data, "%1023s %1023s %2047s",
+							sscanf(mp->data, "%255s %127s %511s",
 							    sreq, smime, spath);
 							if (wj_script_dir[0] != '\0')
 								snprintf(fullpath, sizeof(fullpath),


### PR DESCRIPTION
## Summary

Clean up two `-Wformat-*` warnings on the Linux gcc build of master after the recent PR-#37-through-PR-#42 merges. Two unrelated sites, one trivial commit each.

## Commit 1 — webjacl format-truncation (from PR #37)

PR #37 added two `snprintf` sites in `webjacl.c` (`wj_setupdb` at line 305, `wj_listen` at line 635) without resizing the source `sreq` / `smime` / `spath` buffers that feed them. gcc `-Wformat-truncation` analyses the format string against the *declared* destination sizes — it doesn't see the upstream `sscanf` width specs — so it flags both writes as potentially truncating.

```
webjacl.c:305 -- "up to 1023 bytes into a region of size between 0 and 1023"
webjacl.c:635 -- "up to 2047 bytes into a region of size between 0 and 4095"
```

Both are theoretical given the runtime `%255s %127s %511s` widths, but the cleanest fix is to make the declared sizes match those widths so the analyser can prove safety.

- `wj_setupdb`: `sreq[1024]` → `sreq[256]`; `smime[1024]` → `smime[128]`; `spath[2048]` → `spath[512]`. Worst case `"%s %s %s"` = 255+1+127+1+511+1 = 896, fits `p->data[1024]`.
- `wj_listen`: same local buffer shrinks; `fullpath[4096]` → `fullpath[8192]` for headroom over `wj_script_dir[4096]` + `/` + `spath[512]`. Also tightened the local `sscanf` widths from `%1023s %1023s %2047s` to match `wj_setupdb`'s `%255s %127s %511s` so both sites use the same caps.

No behaviour change: runtime contents were already bounded by the `sscanf` widths.

## Commit 2 — glkterm format-overflow (pre-existing in vendored code)

```
gtfref.c:296: warning: '%s' directive writing up to 255 bytes into a region of size 245
```

`prbuf` is `BUFLEN` (256) bytes; the literal `"Overwrite \"\"? [y/n] "` takes 21 bytes, leaving 235 for `cx` + NUL. The original `sprintf` could overflow by up to 21 bytes when `cx` is near 255 chars (its declared cap). Switched to `snprintf(prbuf, BUFLEN, ...)` — a long filename gets a truncated prompt instead of corrupting the buffer.

This file is vendored CheapGlk-terminal-port code, but you've been patching `glkterm/` in-tree already (commits 55ec0e3 "exit cleanly when stdin pipe closed" and 632c0f3 "fix compiler warnings in bundled libraries"), so the precedent for in-tree fixes here is clear.

## Test plan

- [x] `gcc -Wall -O2 ...` builds cgijacl on Mac (clang) cleanly.
- [x] `gcc -ansi -O -c gtfref.c` builds clean on Mac.
- [ ] You: re-run the original Linux gcc build and confirm both warnings are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)