### PR TITLE
cgijacl: silence CANT_SAVE snprintf truncation warnings on Linux gcc

### DIFF
--- a/src/cgijacl.c
+++ b/src/cgijacl.c
@@ -470,9 +470,12 @@ main(int argc, char *argv[])
     if (save_game(saved_start) == FALSE) {
         /* Treat CANT_SAVE as a plain message, not a format string -- a
          * game that overrides it with a "%n" or unmatched-arg cstring
-         * would otherwise hit a format-string vuln. The filename info
+         * would otherwise hit a format-string vuln. Precision specifiers
+         * cap each piece (cstrings are up to 1024 bytes, saved_start
+         * is up to 256) so the formatted output fits error_buffer
+         * without GCC -Wformat-truncation warnings. The filename info
          * is appended as a separate, engine-controlled line. */
-        snprintf(error_buffer, sizeof error_buffer, "%s [%s]",
+        snprintf(error_buffer, sizeof error_buffer, "%.700s [%.255s]",
                  cstring_resolve("CANT_SAVE")->value, saved_start);
         log_error(error_buffer, PLUS_STDERR);
     }
@@ -541,7 +544,7 @@ main(int argc, char *argv[])
              * back to restart_game() again -- wasted work, plus the
              * misleading log noise. */
             if (save_game(saved_start) == FALSE) {
-                snprintf(error_buffer, sizeof error_buffer, "%s [%s]",
+                snprintf(error_buffer, sizeof error_buffer, "%.700s [%.255s]",
                          cstring_resolve("CANT_SAVE")->value, saved_start);
                 log_error(error_buffer, PLUS_STDERR);
             }
@@ -1216,7 +1219,8 @@ skip_command:
              * the game-defined cstring as a plain message, append the
              * filename info via the engine-controlled "%s [%s/%s]"
              * template. */
-            snprintf(error_buffer, sizeof error_buffer, "%s [%s/%s]",
+            snprintf(error_buffer, sizeof error_buffer,
+                     "%.600s [%.80s/%.255s]",
                      cstring_resolve("CANT_SAVE")->value, prefix, temp_buffer);
             log_error(error_buffer, PLUS_STDOUT);
         }


### PR DESCRIPTION
## Summary

\`make apache\` on a Linux box with glibc fortify (\`__USE_FORTIFY_LEVEL\`) and gcc's \`-Wformat-truncation\` analysis emits three warnings against the CANT_SAVE error reporting introduced in commit 00c61b5. The static analysis correctly notices that the resolved cstring (up to 1024 bytes) plus the path component (up to 256 bytes) can exceed \`error_buffer\`'s 1024-byte capacity.

| Line | Format | Worst case |
|---|---|---|
| 475 | \`\"%s [%s]\"\` | \`msg(1024) + saved_start(256)\` = up to 1283 bytes |
| 544 | \`\"%s [%s]\"\` | same |
| 1219 | \`\"%s [%s/%s]\"\` | \`msg(1024) + prefix(81) + temp_buffer(1024)\` |

## Fix

Cap each piece with an explicit precision so the worst-case output stays under \`sizeof error_buffer - 1\`:

| Line | Was | Now |
|---|---|---|
| 475 | \`\"%s [%s]\"\` | \`\"%.700s [%.255s]\"\` |
| 544 | \`\"%s [%s]\"\` | \`\"%.700s [%.255s]\"\` |
| 1219 | \`\"%s [%s/%s]\"\` | \`\"%.600s [%.80s/%.255s]\"\` |

The localised CANT_SAVE message gets the largest allotment; the filename tail is debug context.

No behavioural change for any realistic message + path: bloodyguns' CANT_SAVE is ~40 chars, well under 700. The cap only matters if a game ships a deliberately enormous override, in which case truncation is the correct response.

## Test plan
- [x] \`make cgijacl\` on macOS clang emits no warnings
- [ ] \`make apache\` on Stuart's Linux box should now compile clean (no \`-Wformat-truncation\` output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)