### PR TITLE
verb libraries: port English audit fixes to translations

### DIFF
--- a/projects/include/french_verbs.library
+++ b/projects/include/french_verbs.library
@@ -1350,7 +1350,6 @@ endif
 override
 if noun1 has ANIMATE
    proxy "attack " noun1{names}
-   endif
 endif
 if noun1 has LIQUID
    write "Une main mouillée est votre seule récompense.^"
@@ -3410,7 +3409,7 @@ ifall noun1 has ANIMATE : noun1 has DEAD
    set time = false
    return true
 endif
-if +worn<noun1 = true
+if +worn<noun2 = true
    return true
 endif
 override
@@ -4957,6 +4956,7 @@ if noun1 = noun2
       write "eux.^"
    else
       write "lui.^"
+   endif
    set time = false
    return true
 endif
@@ -5462,7 +5462,7 @@ integer candidate
 set INDEX = 0
 set candidate = 0
 select *present
-  ifall noun3 has ANIMATE noun3 != player
+  ifall noun3 has ANIMATE : noun3 != player
      set candidate = noun3
      set INDEX + 1
   endif

--- a/projects/include/german_verbs.library
+++ b/projects/include/german_verbs.library
@@ -3256,6 +3256,7 @@ if noun1 = noun2
     write "sich selbst betrachten.^"
   else
     write "sich selbst betrachten.^"
+  endif
   set time = false
   break
 endif

--- a/projects/include/indonesian_verbs.library
+++ b/projects/include/indonesian_verbs.library
@@ -1216,7 +1216,6 @@ endif
 override
 if noun1 has ANIMATE
    proxy "attack " noun1{names}
-   endif
 endif
 if noun1 has LIQUID
    write "Tangan basah adalah satu-satunya hadiah Anda.^"
@@ -3216,7 +3215,7 @@ ifall noun1 has ANIMATE : noun1 has DEAD
    set time = false
    return true
 endif
-if +worn<noun1 = true
+if +worn<noun2 = true
    return true
 endif
 override
@@ -4798,6 +4797,7 @@ if noun1 = noun2
       write "diri mereka sendiri.^"
    else
       write "dirinya sendiri.^"
+   endif
    set time = false
    return true
 endif
@@ -5491,7 +5491,7 @@ integer candidate
 set INDEX = 0
 set candidate = 0
 select *present
-  ifall noun3 has ANIMATE noun3 != player
+  ifall noun3 has ANIMATE : noun3 != player
      set candidate = noun3
      set INDEX + 1
   endif
@@ -5665,9 +5665,10 @@ write "^"
 if here has WITHOUT_AIR
    if tank hasnt WORN
       write "(menahan napas)^"
-endall
+   endif
+endif
 if player has SITTING
-      write "(duduk)^"
+   write "(duduk)^"
 endif
 }
 

--- a/projects/include/spanish_verbs.library
+++ b/projects/include/spanish_verbs.library
@@ -1182,7 +1182,6 @@ endif
 override
 if noun1 has ANIMATE
    proxy "attack " noun1{names}
-   endif
 endif
 if noun1 has LIQUID
    write "Una mano mojada es tu unica recompensa.^"
@@ -3137,7 +3136,7 @@ ifall noun1 has ANIMATE : noun1 has DEAD
    set time = false
    return true
 endif
-if +worn<noun1 = true
+if +worn<noun2 = true
    return true
 endif
 override
@@ -4685,6 +4684,7 @@ if noun1 = noun2
       write "si mismos.^"
    else
       write "si mismo.^"
+   endif
    set time = false
    return true
 endif
@@ -5362,7 +5362,7 @@ integer candidate
 set INDEX = 0
 set candidate = 0
 select *present
-  ifall noun3 has ANIMATE noun3 != player
+  ifall noun3 has ANIMATE : noun3 != player
      set candidate = noun3
      set INDEX + 1
   endif
@@ -5536,9 +5536,10 @@ write "^"
 if here has WITHOUT_AIR
    if tank hasnt WORN
       write "(conteniendo la respiracion)^"
-endall
+   endif
+endif
 if player has SITTING
-      write "(sentado)^"
+   write "(sentado)^"
 endif
 }
 


### PR DESCRIPTION
## Summary

The 5 bugs commit a34e627 fixed in \`projects/include/verbs.library\` recur in the three derivative translations (spanish/indonesian/french). German is on an older snapshot with different structure and only shares one.

| Bug | de | es | id | fr |
|---|---|---|---|---|
| \`+get_animate\` missing colon | — | yes | yes | yes |
| \`+attack_with\` \`+worn<noun1\` → \`<noun2\` | — | yes | yes | yes |
| \`+knock_on\` duplicate endif | — | yes | yes | yes |
| \`+title\` if/endall mismatch | — | yes | yes | — |
| \`+look_at_through\` missing endif | yes | yes | yes | yes |

14 fixes total across 4 files. Same fix shapes as the English commit — see the per-bug rationale in commit message for a34e627.

### Why German has fewer

\`german_verbs.library\` is on a markedly older snapshot of the verbs library (uses \`break +reach noun1\` where the others use \`if +reach<noun1 = true / return true / endif\`, no \`+title\` of the same shape, etc.). Only the \`+look_at_through\` missing-endif bug applies. The other four targets either don't exist or have already-different control flow.

### Why French has no \`+title\` fix

French verbs.library doesn't define \`+title\` — looks like a different status-bar implementation.

## Test plan
- [x] Each library reformatted to the same shape as the English fix; no other lines touched
- [ ] Spot-check: \`grep -n \"ifall noun3 has ANIMATE noun3\"\` returns nothing in all four files (was the missing-colon marker)
- [ ] Optional Stuart: load a Spanish/Indonesian/French game and try \"hug\" with no target — the \`+get_animate\` lookup should now correctly skip the player

🤖 Generated with [Claude Code](https://claude.com/claude-code)