### PR TITLE
display: fix {it} macro on NPCs + NULL guards + bounds checks

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -10,6 +10,40 @@
 #include "encapsulate.h"
 #include "parser.h"
 
+/* All the *_output helpers below share the global `temp_buffer`.
+ * That means a caller who tries to use two macro outputs in the
+ * same write expression (e.g. `write noun1{the} " sees " noun2{that}`)
+ * will see the second call overwrite the first before write_text
+ * gets to send them. The engine's write/print pipeline copies each
+ * argument as it streams output, so the common idiom is safe, but
+ * if you ever store the return value across another *_output call
+ * you must strdup or strcpy it first. */
+
+/* Look up a cstring by name and return its value, falling back to
+ * the supplied literal if the library doesn't define it. Every
+ * *_output below used `cstring_resolve("X")->value` directly, which
+ * segfaults if a stripped-down or in-progress library is missing
+ * X. The fallback keeps the engine alive and substitutes English
+ * defaults the player will recognise. */
+static const char *
+safe_cstr(const char *name, const char *fallback)
+{
+    struct string_type *s = cstring_resolve(name);
+    if (s == NULL) return fallback;
+    return s->value;
+}
+
+/* Guard every *_output entry: many of them are called via macro_
+ * resolve(), which can hand us an integer that came from a game-
+ * side `noun3` pointer (zero / unset) or from a corrupted save.
+ * Without this check object[0] (a sentinel) or object[index] past
+ * the table both deref into garbage. */
+static int
+valid_object(int index)
+{
+    return (index >= 1 && index <= objects && object[index] != NULL);
+}
+
 int
 check_light(int where)
 {
@@ -30,8 +64,11 @@ check_light(int where)
 char *
 sentence_output(int index, int capital)
 {
-	const char *def = object[index]->definite;
+	const char *def;
 	struct string_type *override;
+
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
+	def = object[index]->definite;
 
 	/* If the object still has the loader default "the" and the game
 	 * has set a DEFAULT_DEFINITE constant (e.g. "none" in Indonesian),
@@ -57,8 +94,8 @@ sentence_output(int index, int capital)
 		strcat(temp_buffer, object[index]->inventory);
 	}
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return (temp_buffer);
 }
@@ -66,42 +103,45 @@ sentence_output(int index, int capital)
 char *
 isnt_output(int index)
 {
+	if (!valid_object(index)) return (char *) safe_cstr("ISNT", "isn't");
 	if (object[index]->attributes & PLURAL)
-		return (cstring_resolve("ARENT")->value);
+		return (char *) safe_cstr("ARENT", "aren't");
 	else
-		return (cstring_resolve("ISNT")->value);
+		return (char *) safe_cstr("ISNT", "isn't");
 }
 
 char *
 is_output(int index)
 {
+	if (!valid_object(index)) return (char *) safe_cstr("IS", "is");
 	if (object[index]->attributes & PLURAL)
-		return (cstring_resolve("ARE")->value);
+		return (char *) safe_cstr("ARE", "are");
 	else
-		return (cstring_resolve("IS")->value);
+		return (char *) safe_cstr("IS", "is");
 }
 
 char *
 sub_output(int index, int capital)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	if (object[index]->attributes & PLURAL) {
-		strcpy(temp_buffer, cstring_resolve("THEY_WORD")->value);
+		strcpy(temp_buffer, safe_cstr("THEY_WORD", "they"));
 	} else {
 		if (index == player) {
-			strcpy(temp_buffer, cstring_resolve("YOU_WORD")->value);
+			strcpy(temp_buffer, safe_cstr("YOU_WORD", "you"));
 		} else if (object[index]->attributes & ANIMATE) {
 			if (object[index]->attributes & FEMALE) {
-				strcpy(temp_buffer, cstring_resolve("SHE_WORD")->value);
+				strcpy(temp_buffer, safe_cstr("SHE_WORD", "she"));
 			} else {
-				strcpy(temp_buffer, cstring_resolve("HE_WORD")->value);
+				strcpy(temp_buffer, safe_cstr("HE_WORD", "he"));
 			}
 		} else {
-			strcpy(temp_buffer, cstring_resolve("IT_WORD")->value);
+			strcpy(temp_buffer, safe_cstr("IT_WORD", "it"));
 		}
 	}
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return temp_buffer;
 }
@@ -109,24 +149,25 @@ sub_output(int index, int capital)
 char *
 obj_output(int index, int capital)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	if (object[index]->attributes & PLURAL) {
-		strcpy(temp_buffer, cstring_resolve("THEM_WORD")->value);
+		strcpy(temp_buffer, safe_cstr("THEM_WORD", "them"));
 	} else {
 		if (index == player) {
-			strcpy(temp_buffer, cstring_resolve("YOURSELF_WORD")->value);
+			strcpy(temp_buffer, safe_cstr("YOURSELF_WORD", "yourself"));
 		} else if (object[index]->attributes & ANIMATE) {
 			if (object[index]->attributes & FEMALE) {
-				strcpy(temp_buffer, cstring_resolve("HER_WORD")->value);
+				strcpy(temp_buffer, safe_cstr("HER_WORD", "her"));
 			} else {
-				strcpy(temp_buffer, cstring_resolve("HIM_WORD")->value);
+				strcpy(temp_buffer, safe_cstr("HIM_WORD", "him"));
 			}
 		} else {
-			strcpy(temp_buffer, cstring_resolve("IT_WORD")->value);
+			strcpy(temp_buffer, safe_cstr("IT_WORD", "it"));
 		}
 	}
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return temp_buffer;
 }
@@ -134,28 +175,38 @@ obj_output(int index, int capital)
 char *
 it_output(int index)
 {
-	if (object[index]->attributes & ANIMATE) {
-		return sentence_output(index, FALSE);
-	} else {
-		if (object[index]->attributes & PLURAL) {
-			return (cstring_resolve("THEM_WORD")->value);
+	/* {it} contract per the Author's Guide: prints "they" if PLURAL,
+	 * "he" if ANIMATE, "she" if ANIMATE+FEMALE, "it" otherwise.
+	 * Previously the ANIMATE branch called sentence_output(), which
+	 * returns the object's full noun phrase ("the man"), not a
+	 * pronoun -- a long-standing bug visible to every game that
+	 * used a `noun{it}` macro on an NPC. */
+	if (!valid_object(index)) return (char *) safe_cstr("IT_WORD", "it");
+	if (object[index]->attributes & PLURAL) {
+		return (char *) safe_cstr("THEY_WORD", "they");
+	} else if (object[index]->attributes & ANIMATE) {
+		if (object[index]->attributes & FEMALE) {
+			return (char *) safe_cstr("SHE_WORD", "she");
 		} else {
-			return (cstring_resolve("IT_WORD")->value);
+			return (char *) safe_cstr("HE_WORD", "he");
 		}
+	} else {
+		return (char *) safe_cstr("IT_WORD", "it");
 	}
 }
 
 char *
 that_output(int index, int capital)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	if (object[index]->attributes & PLURAL) {
-		strcpy(temp_buffer, cstring_resolve("THOSE_WORD")->value);
+		strcpy(temp_buffer, safe_cstr("THOSE_WORD", "those"));
 	} else {
-		strcpy(temp_buffer, cstring_resolve("THAT_WORD")->value);
+		strcpy(temp_buffer, safe_cstr("THAT_WORD", "that"));
 	}
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return temp_buffer;
 }
@@ -163,24 +214,27 @@ that_output(int index, int capital)
 char *
 doesnt_output(int index)
 {
+	if (!valid_object(index)) return (char *) safe_cstr("DOESNT", "doesn't");
 	if (object[index]->attributes & PLURAL)
-		return (cstring_resolve("DONT")->value);
+		return (char *) safe_cstr("DONT", "don't");
 	else
-		return (cstring_resolve("DOESNT")->value);
+		return (char *) safe_cstr("DOESNT", "doesn't");
 }
 
 char *
 does_output(int index)
 {
+	if (!valid_object(index)) return (char *) safe_cstr("DOES", "does");
 	if (object[index]->attributes & PLURAL)
-		return (cstring_resolve("DO")->value);
+		return (char *) safe_cstr("DO", "do");
 	else
-		return (cstring_resolve("DOES")->value);
+		return (char *) safe_cstr("DOES", "does");
 }
 
 char *
 list_output(int index, int capital)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	if (!strcmp(object[index]->article, "name")) {
 		strcpy(temp_buffer, object[index]->inventory);
 	} else {
@@ -189,8 +243,8 @@ list_output(int index, int capital)
 		strcat(temp_buffer, object[index]->inventory);
 	}
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return (temp_buffer);
 }
@@ -198,10 +252,11 @@ list_output(int index, int capital)
 char *
 plain_output(int index, int capital)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	strcpy(temp_buffer, object[index]->inventory);
 
-	if (capital)
-		temp_buffer[0] = toupper(temp_buffer[0]);
+	if (capital && (unsigned char) temp_buffer[0] < 0x80)
+		temp_buffer[0] = toupper((unsigned char) temp_buffer[0]);
 
 	return (temp_buffer);
 }
@@ -209,6 +264,7 @@ plain_output(int index, int capital)
 char *
 long_output(int index)
 {
+	if (!valid_object(index)) { temp_buffer[0] = 0; return temp_buffer; }
 	if (!strcmp(object[index]->described, "function")) {
 		strcpy(function_name, "long_");
 		strcat(function_name, object[index]->label);
@@ -228,9 +284,9 @@ long_output(int index)
 void
 no_it()
 {
-	write_text(cstring_resolve("NO_IT")->value);
+	write_text(safe_cstr("NO_IT", "I don't see "));
 	write_text(word[wp]);
-	write_text(cstring_resolve("NO_IT_END")->value);
+	write_text(safe_cstr("NO_IT_END", " here."));
 	custom_error = TRUE;
 }
 


### PR DESCRIPTION
## Summary

Deep audit of \`src/display.c\` — the macro pipeline every \`{the}\` / \`{is}\` / \`{it}\` / \`{sub}\` etc. flows through. Four findings, three of which are real and shipped today.

### \`{it}\` returns the wrong text for NPCs (HIGH, real bug)

Per the Author's Guide, \`noun{it}\` should print \`they\` / \`he\` / \`she\` / \`it\` depending on PLURAL / ANIMATE / FEMALE. The current ANIMATE branch instead returns \`sentence_output(index, FALSE)\` — the object's full noun phrase. Any game that wrote \`noun{it}\` on an NPC saw \`\"the man\"\` instead of \`\"he\"\`. Restructured to mirror \`sub_output\`'s branching.

### NULL deref on missing localisation cstring (HIGH)

Every \`*_output\` that branched on PLURAL/ANIMATE/FEMALE did \`cstring_resolve(\"X\")->value\` with no NULL check. \`cstring_resolve\` returns NULL if the key isn't in the cstring table (e.g. a stripped-down or in-progress library shipped without ARENT / DONT / HE_WORD / THEY_WORD / etc.) → instant segfault on first use. New \`safe_cstr(name, fallback)\` helper falls back to an English literal.

### \`object[index]\` not bounds-checked (HIGH)

Every \`*_output\` dereferenced \`object[index]\` without verifying \`1 <= index <= objects\`. A game with \`noun3{the}\` while \`noun3 == 0\` read \`object[0]\` (sentinel slot); a corrupted save could land arbitrarily out of range. Added \`valid_object()\` guard at the top of every entry; bad index returns empty \`temp_buffer\` (for buffered outputs) or the IT_WORD / IS / DOES fallback (for direct returns).

### \`toupper\` on UTF-8 leading byte (LOW polish)

Every \`temp_buffer[0] = toupper(temp_buffer[0])\` passed signed \`char\` with the high bit set straight to \`toupper\` (undefined behaviour per C99 unless \`unsigned char\`-cast or EOF). Localised inventories starting with \`Über\`, \`Étoile\` etc. either silently no-op (best case) or corrupt the leading byte. Now gated on \`< 0x80\` with an explicit unsigned cast so multi-byte words pass through unchanged.

### Re-entrancy (documented, not fixed)

\`temp_buffer\` is a global shared between every \`*_output\`. A caller chaining two of them in the same expression and storing the first result across the second call would see the first overwritten. The engine's write/print streamer copies as it goes, so the common idiom is safe; documented with a top-of-file comment for anyone adding new callers.

## Test plan
- [x] All sources compile cleanly with \`-Wall\`; only the linker fails on the root-owned binary (\`sudo make install\` to install)
- [ ] Spot-check (Stuart): in a game with at least one animate NPC, try \`write npc{it}\` — should print \`he\` / \`she\` not \`the npc\`
- [ ] Optional: deliberately drop a key like \`ARENT\` from a custom library and load — should print \`aren't\` (English fallback) instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)