### PR TITLE
GLK build hardening: status line + UTF-8 input + save restore

### DIFF
--- a/src/glk_saver.c
+++ b/src/glk_saver.c
@@ -172,19 +172,48 @@ restore_game(frefid_t saveref, int warn)
 
     while (current_string != NULL) {
 		for (index = 0; index < 1024; index++) {
-    		current_string->value[index] = glk_get_char_stream(bookmark);
+			glsi32 c = glk_get_char_stream(bookmark);
+			/* Truncated save returns -1 on EOF; without this check
+			 * the value field gets filled with 0xFF for the whole
+			 * 1024 bytes and the rest of the read goes haywire. */
+			if (c < 0) c = 0;
+			current_string->value[index] = (char) c;
 		}
+		/* string_type::value is [1025]; defensively NUL-terminate so
+		 * subsequent strlen on a string whose last byte happens to
+		 * be non-zero doesn't walk past the buffer end. */
+		current_string->value[1024] = 0;
         current_string = current_string->next_string;
     }
 
 	/* Matches the save side: pull last_command back so 'again' still
 	 * has a target after the restore. */
 	for (index = 0; index < 1024; index++) {
-		last_command[index] = glk_get_char_stream(bookmark);
+		glsi32 c = glk_get_char_stream(bookmark);
+		if (c < 0) c = 0;
+		last_command[index] = (char) c;
 	}
 
-	player = read_integer(bookmark);
-	noun[3] = read_integer(bookmark);
+	{
+		int saved_player = read_integer(bookmark);
+		int saved_noun3  = read_integer(bookmark);
+		/* Same defence as saver.c: refuse a player value past the
+		 * end of the object table. 0 is allowed (legitimate "no
+		 * player yet" state). noun[3] is unchecked because -1
+		 * ("no second noun") and 0 (FALSE) are both legal. */
+		if (saved_player < 0 || saved_player > objects) {
+			if (warn == FALSE) {
+				sprintf(error_buffer,
+				        "Saved file has out-of-range player (%d, objects=%d); refusing restore.",
+				        saved_player, objects);
+				log_error(error_buffer, PLUS_STDOUT);
+			}
+			glk_stream_close(bookmark, NULL);
+			return (FALSE);
+		}
+		player  = saved_player;
+		noun[3] = saved_noun3;
+	}
 
 	/* RESTORE THE CURRENT VOLUME OF EACH OF THE SOUND CHANNELS */
 	for (index = 0; index < 8; index++) {

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -940,8 +940,16 @@ status_line()
 	if (execute("+update_status_window") == FALSE) {
 		glk_set_style(style_User1);
 
-		/* DISPLAY THE INVERSE STATUS LINE AT THE TOP OF THE SCREEN */
-		for (index = 0; index < status_width; index++) {
+		/* DISPLAY THE INVERSE STATUS LINE AT THE TOP OF THE SCREEN.
+		 * Clamp the fill width to temp_buffer's capacity: status_width
+		 * is a glui32 from Glk and on a very wide window (Gargoyle
+		 * resized full-screen on a hi-DPI display) it can exceed
+		 * 1024, overrunning temp_buffer. */
+		glui32 fill_width = status_width;
+		if (fill_width >= sizeof(temp_buffer)) {
+			fill_width = sizeof(temp_buffer) - 1;
+		}
+		for (index = 0; index < (int) fill_width; index++) {
 			temp_buffer[index] = ' ';
 		}
 		temp_buffer[index] = 0;
@@ -955,8 +963,18 @@ status_line()
 		temp_buffer[0] = 0;
 		sprintf (temp_buffer, "Score: %d  Moves: %d", SCORE->value, TOTAL_MOVES->value);
 
-		cursor = status_width - strlen(temp_buffer);
-		cursor--;
+		/* Compute right-justified cursor; if the score/moves string
+		 * is wider than the window, fall back to column 0 rather
+		 * than letting (status_width - strlen) underflow into a
+		 * huge glui32. */
+		{
+			size_t tb_len = strlen(temp_buffer);
+			if (tb_len + 1 < status_width) {
+				cursor = status_width - tb_len - 1;
+			} else {
+				cursor = 0;
+			}
+		}
 		glk_window_move_cursor(statuswin, cursor, 0);
 		write_text(temp_buffer);
 	}
@@ -1599,12 +1617,18 @@ add_word(const char * word)
 void 
 convert_to_utf8(glui32 *text, int len) {
 	int i, k;
+	/* command_buffer is 1024 bytes; a 4-byte UTF-8 sequence plus the
+	 * trailing NUL means we can't safely write past index
+	 * sizeof - 5. Without this cap, a long input of high-codepoint
+	 * characters would overflow (e.g. 256 emoji = 1024 output bytes
+	 * + NUL = one-byte overrun). */
+	const int cap = (int) sizeof(command_buffer) - 5;
 
 	i = 0;
 	k = 0;
 
 	/*convert UTF-32 to UTF-8 */
-	while (i < len) {
+	while (i < len && k < cap) {
 		if (text[i] < 0x80) {
 			command_buffer[k] = text[i];
 			k++;


### PR DESCRIPTION
## Summary
Closes out the GLK-target half of the C audit — three concrete buffer / underflow / EOF bugs in code that only the `jacl` (Glk-windowed) and `cjacl` (CheapGlk) builds reach.

### jacl.c — status line + UTF-8 input
- `status_line()` clamps `status_width` against `sizeof(temp_buffer)` before space-filling. A wide terminal where `status_width > 1024` previously walked the fill loop past `temp_buffer[]`.
- Same path: when the assembled status text was wider than the window, the suffix-cursor computation underflowed (`cursor = status_width - strlen(temp_buffer); cursor--;` with `temp_buffer` longer than `status_width` produced `UINT_MAX`), writing the score/turns suffix off-screen. Now falls back to 0.
- `convert_to_utf8()` bounds the output index against `sizeof(command_buffer) - 5`. A four-byte UTF-8 codepoint on the final input character was capable of writing past the buffer end.

### glk_saver.c — restore_game guards
- Both read loops now check `glk_get_char_stream()` for `-1` (EOF). A truncated `.save` previously filled the buffer with `0xFF` for the full 1024 bytes and the subsequent reads then ran on garbage.
- `string_type::value[1024]` is explicitly NUL-terminated after the loop; later `strlen()` on a string whose last byte happens to be non-zero could otherwise walk off the end.
- `player` is validated against `[0, objects]` before assignment. Same shape as the saver.c guard added in 1d9d359. `noun[3]` is left alone because `-1` ("no second noun") and `0` (`FALSE`) are both legitimate values — a regression I caused in that earlier guard.

## Test plan
- [x] `make jacl` compiles cleanly (link step fails locally because `bin/jacl` is root-owned from a prior `sudo make install`; `sudo make install` rebuilds it)
- [ ] After install, smoke-test save / restore round-trip in a Glk session
- [ ] Resize the terminal so `status_width` > 80 and confirm the status line no longer wraps or corrupts

🤖 Generated with [Claude Code](https://claude.com/claude-code)