### PR TITLE
iOS: build + runtime fixes — app now runs on iPad simulator

### DIFF
--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -48,6 +48,10 @@ final class GlkBridge: ObservableObject {
     private var generation = 0
     private var splitter = JSONObjectStream()
     private let readerQueue = DispatchQueue(label: "jacl.remglk.reader")
+    // Writes MUST be on their own queue: the reader queue is occupied forever
+    // by a blocking read() loop, so a write dispatched there would never run
+    // (the init event would never reach the terp -> blank screen / deadlock).
+    private let writerQueue = DispatchQueue(label: "jacl.remglk.writer")
 
     // MARK: Lifecycle
 
@@ -117,7 +121,7 @@ final class GlkBridge: ObservableObject {
     private func send(_ event: GlkEvent) {
         let data = event.jsonData()
         let fd = appFD
-        readerQueue.async {                                // serialize writes off the UI thread
+        writerQueue.async {                                // own queue, NOT the blocked reader queue
             data.withUnsafeBytes { raw in
                 _ = write(fd, raw.baseAddress, raw.count)
             }

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -16,7 +16,20 @@ import UniformTypeIdentifiers
 struct JACLApp: App {
     var body: some Scene {
         WindowGroup {
+            #if DEBUG
+            // Debug-only hook: `simctl launch … -autoplay` opens the first
+            // imported game straight into the game view, so the RemGlk bridge
+            // can be exercised headlessly. Normal launches (and all release
+            // builds) show the shelf.
+            if ProcessInfo.processInfo.arguments.contains("-autoplay"),
+               let game = GameLibrary.games().first {
+                GameView(gamePath: game.path)
+            } else {
+                GameShelfView()
+            }
+            #else
             GameShelfView()
+            #endif
         }
     }
 }

--- a/ios/ios_startup.c
+++ b/ios/ios_startup.c
@@ -46,10 +46,9 @@ int             jpp_error = FALSE;
  * in the desktop build and we are its replacement). */
 strid_t         blorb_stream;
 
-/* Vestigial in the .j2 path: only the desktop -noencrypt flag ever wrote
- * it, and nothing in the core reads it. Defined so the symbol exists if a
- * future translation unit references it, matching glk_startup.c. */
-short int       encrypt;
+/* (glk_startup.c also defines a vestigial `short int encrypt;` here, but it
+ * is omitted on purpose: nothing in the iOS build reads it, and the name
+ * collides with POSIX encrypt() from <unistd.h> on the iOS SDK.) */
 
 /* The game file the host app wants us to run. Set by the app shell before
  * the interpreter thread starts; read by glkunix_startup_code() when a


### PR DESCRIPTION
Follow-up to #60. The merged foundation doesn't compile for iOS as-is: `ios_startup.c` defines a vestigial `short int encrypt;` that collides with POSIX `encrypt()` from `<unistd.h>` (the iOS SDK pulls it into scope; the desktop Glk headers didn't, so the sims built fine). Nothing in the iOS build reads it — removed.

**Verified with a real build** (`xcodebuild -sdk iphonesimulator26.5`): the whole stack now compiles and links — C core cross-compiled to arm64+x86_64, vendored RemGlk, the bridge, and all four SwiftUI files type-checked against the iOS 26.5 SDK. Resulting `JACL.app` links `glk_main` / `remglk_main` / `jacl_bridge_run` and registers the `.j2` document type. Desktop sims (`make sim`/`cheap`/`remglk`) still build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)