### PR TITLE
web: .jaclgame downloads + "Get it for iPad" landing-page tab

### DIFF
--- a/etc/build-jaclgames.sh
+++ b/etc/build-jaclgames.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+# build-jaclgames.sh -- build .jaclgame download packages for the iPad app,
+# one per published game (constant game_publish true).
+#
+#   build-jaclgames.sh [PROJECTS_DIR] [OUT_DIR] [CJACL]
+#
+# Defaults: PROJECTS_DIR=../projects  OUT_DIR=$PROJECTS_DIR/jaclgames
+#           CJACL=../bin/cjacl
+#
+# Each package is a zip (flat entries) of the game's release .j2 plus its
+# .blorb, if any. The app imports it via "Open in JACL" and unpacks it.
+
+set -e
+
+projects="${1:-../projects}"
+out="${2:-$projects/jaclgames}"
+cjacl="${3:-../bin/cjacl}"
+
+if [ ! -x "$cjacl" ]; then
+    echo "build-jaclgames: interpreter '$cjacl' not found/executable" >&2
+    exit 1
+fi
+
+mkdir -p "$out"
+n=0
+for game in "$projects"/*.jacl; do
+    [ -e "$game" ] || continue
+    grep -qE '^constant[[:space:]]+game_publish[[:space:]]+true' "$game" || continue
+
+    name=$(basename "$game" .jacl)
+
+    # Build the release (debug-free, obfuscated) .j2 -- written to the temp
+    # dir beside the game source.
+    "$cjacl" "$game" -release </dev/null >/dev/null 2>&1 || true
+    j2="$projects/temp/$name.j2"
+    if [ ! -f "$j2" ]; then
+        echo "  skip $name (no .j2 produced)"
+        continue
+    fi
+
+    pkg="$out/$name.jaclgame"
+    rm -f "$pkg"
+    tmp=$(mktemp -d)
+    cp "$j2" "$tmp/$name.j2"
+    if [ -f "$projects/$name.blorb" ]; then
+        cp "$projects/$name.blorb" "$tmp/$name.blorb"
+        ( cd "$tmp" && zip -j -q "$name.jaclgame" "$name.j2" "$name.blorb" )
+    else
+        ( cd "$tmp" && zip -j -q "$name.jaclgame" "$name.j2" )
+    fi
+    mv "$tmp/$name.jaclgame" "$pkg"
+    rm -rf "$tmp"
+    n=$((n + 1))
+    echo "  $name.jaclgame"
+done
+echo "build-jaclgames: $n package(s) in $out"

--- a/etc/gen-landing.sh
+++ b/etc/gen-landing.sh
@@ -1,0 +1,131 @@
+#!/bin/sh
+# gen-landing.sh -- generate the JACL landing page (index.html) on stdout.
+#
+#   gen-landing.sh [PROJECTS_DIR] [GAMES_DIR]
+#
+# PROJECTS_DIR: where the .jacl sources live (for titles / languages).
+# GAMES_DIR:    where built .jaclgame packages live; the "Get it for iPad"
+#               tab lists only games that have one.
+#
+# Two CSS-only tabs (no JavaScript): "Play Online" (fcgijacl links) and
+# "Get it for iPad" (.jaclgame downloads).
+
+projects="${1:-../projects}"
+games="${2:-$projects/jaclgames}"
+
+# Resolve $title and $lang for a game source file.
+game_meta() {
+    g="$1"
+    name=$(basename "$g" .jacl)
+    title_line=$(grep -E '^constant[[:space:]]+game_title[[:space:]]' "$g" 2>/dev/null | head -1)
+    title=$(echo "$title_line" | sed -E 's/.*"([^"]+)".*/\1/')
+    if [ -z "$title" ] || [ "$title" = "$title_line" ]; then
+        title="$name"
+    fi
+    if grep -q '^#include "indonesian_verbs.library"' "$g"; then lang="Indonesian"
+    elif grep -q '^#include "spanish_verbs.library"' "$g"; then lang="Spanish"
+    elif grep -q '^#include "french_verbs.library"\|^#include "french_webinterface.library"' "$g"; then lang="French"
+    elif grep -q '^#include "german_verbs.library"' "$g"; then lang="German"
+    else lang="English"; fi
+}
+
+cat <<'HEAD'
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>JACL Interactive Fiction</title>
+  <style>
+    :root { --accent: #42596d; --accent-dark: #2c3e50; --bg: #f5f1ea; --card: #fff; --muted: #6b6b6b; }
+    * { box-sizing: border-box; }
+    body { font-family: Georgia, Palatino, Times, serif; margin: 0; padding: 0; color: #2c2c2c; line-height: 1.6; background: var(--bg); }
+    header.hero { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; padding: 3em 1em 2em; text-align: center; }
+    header.hero h1 { margin: 0 0 0.3em; font-size: 2.4em; letter-spacing: 0.02em; }
+    header.hero p { margin: 0; opacity: 0.9; font-style: italic; font-size: 1.05em; }
+    nav.topnav { background: #2c3e50; text-align: center; padding: 0.5em; }
+    nav.topnav a { color: #fff; text-decoration: none; margin: 0 1em; font-size: 0.95em; }
+    nav.topnav a:hover { text-decoration: underline; }
+    main { max-width: 760px; margin: 2em auto; padding: 0 1em; }
+    section.intro { background: var(--card); padding: 1.5em 1.8em; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); margin-bottom: 2em; }
+    section.intro p { margin: 0 0 0.8em; }
+    section.intro p:last-child { margin-bottom: 0; }
+    h2 { color: var(--accent-dark); border-bottom: 2px solid var(--accent); padding-bottom: 0.3em; margin-top: 0; }
+    ul.games { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.9em; }
+    ul.games li { background: var(--card); border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); transition: transform 0.1s, box-shadow 0.1s; }
+    ul.games li:hover { transform: translateY(-2px); box-shadow: 0 3px 8px rgba(0,0,0,0.12); }
+    ul.games a { display: block; padding: 0.9em 1.1em; text-decoration: none; color: var(--accent); font-weight: bold; font-size: 1.05em; }
+    ul.games .lang { color: var(--muted); font-weight: normal; font-size: 0.88em; margin-left: 0.3em; }
+    nav.tabs { display: flex; gap: 0.4em; border-bottom: 2px solid var(--accent); margin-bottom: 1.4em; }
+    nav.tabs label { padding: 0.55em 1.2em; cursor: pointer; color: var(--muted); font-weight: bold; border-radius: 6px 6px 0 0; }
+    input.tabsel { position: absolute; left: -9999px; }
+    .tabpane { display: none; }
+    #tab-play:checked ~ .tabpane.play { display: block; }
+    #tab-get:checked ~ .tabpane.get { display: block; }
+    #tab-play:checked ~ nav.tabs label[for=tab-play],
+    #tab-get:checked ~ nav.tabs label[for=tab-get] { color: var(--accent-dark); background: var(--card); box-shadow: 0 -1px 3px rgba(0,0,0,0.06); }
+    p.tabintro { color: var(--muted); margin: 0 0 1.2em; }
+    footer { margin: 3em 1em 2em; color: var(--muted); font-size: 0.85em; text-align: center; }
+    footer a { color: var(--accent); }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <h1>JACL Interactive Fiction</h1>
+    <p>Text adventures by Stuart Allen, written in JACL</p>
+  </header>
+  <nav class="topnav">
+    <a href="/guide/">Guide</a>
+    <a href="https://github.com/DangarStu/JACL">Source</a>
+  </nav>
+  <main>
+    <section class="intro">
+      <p><strong>Interactive fiction</strong> is a genre of text-based computer games where you read a description of a scene and type simple commands (for example <em>go north</em>, <em>take lamp</em>, or <em>examine desk</em>) to move through a story and solve its puzzles.</p>
+      <p>It is a direct descendant of the text adventures of the 1970s and 80s &mdash; titles like <em>Zork</em>, <em>Adventure</em>, and <em>The Hitchhiker&rsquo;s Guide to the Galaxy</em> &mdash; and has a thriving modern community of authors and players.</p>
+      <p>Want to write your own? The <a href="/guide/">JACL Guide</a> walks you through the language.</p>
+      <p>The interpreter source code &mdash; for running JACL locally or contributing &mdash; is on <a href="https://github.com/DangarStu/JACL">GitHub</a>.</p>
+    </section>
+    <input class="tabsel" type="radio" name="tab" id="tab-play" checked>
+    <input class="tabsel" type="radio" name="tab" id="tab-get">
+    <nav class="tabs">
+      <label for="tab-play">Play Online</label>
+      <label for="tab-get">Get it for iPad</label>
+    </nav>
+    <div class="tabpane play">
+      <h2>Play a game</h2>
+      <ul class="games">
+HEAD
+
+# --- Play Online list ---
+for game in "$projects"/*.jacl; do
+    [ -e "$game" ] || continue
+    grep -qE '^constant[[:space:]]+game_publish[[:space:]]+true' "$game" || continue
+    game_meta "$game"
+    printf '        <li><a href="/jacl/%s.fcgi">%s <span class="lang">(%s)</span></a></li>\n' "$name" "$title" "$lang"
+done
+
+cat <<'MID'
+      </ul>
+    </div>
+    <div class="tabpane get">
+      <h2>Get it for iPad</h2>
+      <p class="tabintro">Download a game on your iPad and choose <strong>Open in JACL</strong> to play it in the app &mdash; offline, with graphics. Each download is a single <code>.jaclgame</code> file.</p>
+      <ul class="games">
+MID
+
+# --- Get it for iPad list (only games with a built package) ---
+for game in "$projects"/*.jacl; do
+    [ -e "$game" ] || continue
+    grep -qE '^constant[[:space:]]+game_publish[[:space:]]+true' "$game" || continue
+    game_meta "$game"
+    [ -f "$games/$name.jaclgame" ] || continue
+    printf '        <li><a href="/games/%s.jaclgame" download>%s <span class="lang">(%s)</span></a></li>\n' "$name" "$title" "$lang"
+done
+
+cat <<'TAIL'
+      </ul>
+    </div>
+  </main>
+  <footer>Served by JACL. Online games run via the fcgijacl interpreter. <a href="/guide/">Read the Guide</a> to write your own.</footer>
+</body></html>
+TAIL

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -106,78 +106,11 @@ apache: install
 	@echo "Deploying JACL Guide to /var/www/html/guide/..."
 	@mkdir -p /var/www/html/guide
 	@cp -r ../guide/* /var/www/html/guide/
+	@echo "Building .jaclgame download packages for iPad..."
+	@mkdir -p /var/www/html/games
+	@sh ../etc/build-jaclgames.sh /usr/local/jacl/projects /var/www/html/games ../bin/cjacl || true
 	@echo "Building landing-page index.html..."
-	@mkdir -p /var/www/html
-	@{ \
-	  printf '%s\n' '<!DOCTYPE html>'; \
-	  printf '%s\n' '<html lang="en">'; \
-	  printf '%s\n' '<head>'; \
-	  printf '%s\n' '  <meta charset="UTF-8">'; \
-	  printf '%s\n' '  <meta name="viewport" content="width=device-width, initial-scale=1">'; \
-	  printf '%s\n' '  <title>JACL Interactive Fiction</title>'; \
-	  printf '%s\n' '  <style>'; \
-	  printf '%s\n' '    :root { --accent: #42596d; --accent-dark: #2c3e50; --bg: #f5f1ea; --card: #fff; --muted: #6b6b6b; }'; \
-	  printf '%s\n' '    * { box-sizing: border-box; }'; \
-	  printf '%s\n' '    body { font-family: Georgia, Palatino, Times, serif; margin: 0; padding: 0; color: #2c2c2c; line-height: 1.6; background: var(--bg); }'; \
-	  printf '%s\n' '    header.hero { background: linear-gradient(135deg, var(--accent-dark), var(--accent)); color: #fff; padding: 3em 1em 2em; text-align: center; }'; \
-	  printf '%s\n' '    header.hero h1 { margin: 0 0 0.3em; font-size: 2.4em; letter-spacing: 0.02em; }'; \
-	  printf '%s\n' '    header.hero p { margin: 0; opacity: 0.9; font-style: italic; font-size: 1.05em; }'; \
-	  printf '%s\n' '    nav.topnav { background: #2c3e50; text-align: center; padding: 0.5em; }'; \
-	  printf '%s\n' '    nav.topnav a { color: #fff; text-decoration: none; margin: 0 1em; font-size: 0.95em; }'; \
-	  printf '%s\n' '    nav.topnav a:hover { text-decoration: underline; }'; \
-	  printf '%s\n' '    main { max-width: 760px; margin: 2em auto; padding: 0 1em; }'; \
-	  printf '%s\n' '    section.intro { background: var(--card); padding: 1.5em 1.8em; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.05); margin-bottom: 2em; }'; \
-	  printf '%s\n' '    section.intro p { margin: 0 0 0.8em; }'; \
-	  printf '%s\n' '    section.intro p:last-child { margin-bottom: 0; }'; \
-	  printf '%s\n' '    h2 { color: var(--accent-dark); border-bottom: 2px solid var(--accent); padding-bottom: 0.3em; margin-top: 0; }'; \
-	  printf '%s\n' '    ul.games { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.9em; }'; \
-	  printf '%s\n' '    ul.games li { background: var(--card); border-radius: 6px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); transition: transform 0.1s, box-shadow 0.1s; }'; \
-	  printf '%s\n' '    ul.games li:hover { transform: translateY(-2px); box-shadow: 0 3px 8px rgba(0,0,0,0.12); }'; \
-	  printf '%s\n' '    ul.games a { display: block; padding: 0.9em 1.1em; text-decoration: none; color: var(--accent); font-weight: bold; font-size: 1.05em; }'; \
-	  printf '%s\n' '    ul.games .lang { color: var(--muted); font-weight: normal; font-size: 0.88em; margin-left: 0.3em; }'; \
-	  printf '%s\n' '    footer { margin: 3em 1em 2em; color: var(--muted); font-size: 0.85em; text-align: center; }'; \
-	  printf '%s\n' '    footer a { color: var(--accent); }'; \
-	  printf '%s\n' '  </style>'; \
-	  printf '%s\n' '</head>'; \
-	  printf '%s\n' '<body>'; \
-	  printf '%s\n' '  <header class="hero">'; \
-	  printf '%s\n' '    <h1>JACL Interactive Fiction</h1>'; \
-	  printf '%s\n' '    <p>Text adventures by Stuart Allen, written in JACL</p>'; \
-	  printf '%s\n' '  </header>'; \
-	  printf '%s\n' '  <nav class="topnav">'; \
-	  printf '%s\n' '    <a href="/guide/">Guide</a>'; \
-	  printf '%s\n' '    <a href="https://github.com/DangarStu/JACL">Source</a>'; \
-	  printf '%s\n' '  </nav>'; \
-	  printf '%s\n' '  <main>'; \
-	  printf '%s\n' '    <section class="intro">'; \
-	  printf '%s\n' '      <p><strong>Interactive fiction</strong> is a genre of text-based computer games where you read a description of a scene and type simple commands (for example <em>go north</em>, <em>take lamp</em>, or <em>examine desk</em>) to move through a story and solve its puzzles.</p>'; \
-	  printf '%s\n' '      <p>It is a direct descendant of the text adventures of the 1970s and 80s &mdash; titles like <em>Zork</em>, <em>Adventure</em>, and <em>The Hitchhiker&rsquo;s Guide to the Galaxy</em> &mdash; and has a thriving modern community of authors and players.</p>'; \
-	  printf '%s\n' '      <p>Want to write your own? The <a href="/guide/">JACL Guide</a> walks you through the language.</p>'; \
-	  printf '%s\n' '      <p>The interpreter source code &mdash; for running JACL locally or contributing &mdash; is on <a href="https://github.com/DangarStu/JACL">GitHub</a>.</p>'; \
-	  printf '%s\n' '    </section>'; \
-	  printf '%s\n' '    <h2>Play a game</h2>'; \
-	  printf '%s\n' '    <ul class="games">'; \
-	  for game in /usr/local/jacl/projects/*.jacl; do \
-	    [ -e "$$game" ] || continue; \
-	    name=$$(basename "$$game" .jacl); \
-	    grep -q '^constant[[:space:]]\+game_publish[[:space:]]\+true' "$$game" 2>/dev/null || continue; \
-	    title_line=$$(grep -E '^constant[[:space:]]+game_title[[:space:]]' "$$game" 2>/dev/null | head -1); \
-	    title=$$(echo "$$title_line" | sed -E 's/.*"([^"]+)".*/\1/'); \
-	    if [ -z "$$title" ] || [ "$$title" = "$$title_line" ]; then \
-	      title="$$name"; \
-	    fi; \
-	    if grep -q '^#include "indonesian_verbs.library"' "$$game"; then lang="Indonesian"; \
-	    elif grep -q '^#include "spanish_verbs.library"' "$$game"; then lang="Spanish"; \
-	    elif grep -q '^#include "french_verbs.library"\|^#include "french_webinterface.library"' "$$game"; then lang="French"; \
-	    elif grep -q '^#include "german_verbs.library"' "$$game"; then lang="German"; \
-	    else lang="English"; fi; \
-	    printf '      <li><a href="/jacl/%s.fcgi">%s <span class="lang">(%s)</span></a></li>\n' "$$name" "$$title" "$$lang"; \
-	  done; \
-	  printf '%s\n' '    </ul>'; \
-	  printf '%s\n' '  </main>'; \
-	  printf '%s\n' '  <footer>Served by JACL. Each game runs via the fcgijacl interpreter. <a href="/guide/">Read the Guide</a> to write your own.</footer>'; \
-	  printf '%s\n' '</body></html>'; \
-	} > /var/www/html/index.html
+	@sh ../etc/gen-landing.sh /usr/local/jacl/projects /var/www/html/games > /var/www/html/index.html
 	@echo "Installing Apache configuration..."
 	cp ../etc/jacl-apache.conf /etc/apache2/conf-available/jacl.conf
 	a2enconf jacl


### PR DESCRIPTION
Addresses the gap that the website only links to **play online** — adds an iPad **download** tab beside it.

The `make apache` landing page now has two CSS-only tabs (no JS):
- **Play Online** — the existing `fcgijacl` links.
- **Get it for iPad** — a `.jaclgame` download per published game, with a short "download then Open in JACL" note.

### Changes
- **`etc/build-jaclgames.sh`** — builds a `.jaclgame` (release `.j2` + `.blorb`) for every `game_publish true` game into the web games dir.
- **`etc/gen-landing.sh`** — generates the tabbed landing page. Extracted from the giant inline `Makefile` block so it's **testable** and no longer duplicated across `Makefile`/`Makefile.in`.
- **`Makefile.in`** `apache` target — builds packages into `/var/www/html/games` and calls `gen-landing.sh`.

### Verified
Ran both generators locally against the repo: all **16 published games** package and list correctly in both tabs; tab scaffolding + links are correct. The full `apache` target itself needs a deployment box (sudo/Apache) so I couldn't run it end-to-end — but the package build and page generation are tested in isolation.

Needs `bin/cjacl` to build the release `.j2`s. Run `./configure` to regenerate the git-ignored `Makefile`.

Standalone web-side change (based on the iOS graphics branch for a clean diff; can be rebased onto master independently). 🤖 Generated with [Claude Code](https://claude.com/claude-code)