### PR TITLE
build: standalone jpp preprocessor for .jaclgame packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ src/cgijacl
 src/cjacl
 src/fcgijacl
 src/jacl
+src/jpp
 
 # editor / tool local config
 .claude/

--- a/etc/build-jaclgames.sh
+++ b/etc/build-jaclgames.sh
@@ -2,10 +2,16 @@
 # build-jaclgames.sh -- build .jaclgame download packages for the iPad app,
 # one per published game (constant game_publish true).
 #
-#   build-jaclgames.sh [PROJECTS_DIR] [OUT_DIR] [CJACL]
+#   build-jaclgames.sh [PROJECTS_DIR] [OUT_DIR] [JPP]
 #
 # Defaults: PROJECTS_DIR=../projects  OUT_DIR=$PROJECTS_DIR/jaclgames
-#           CJACL=../bin/cjacl
+#           JPP=jpp  (the standalone preprocessor; resolved from PATH)
+#
+# JPP is the jpp(1) preprocessor utility, not a full interpreter: it just
+# writes the release .j2 and exits, so there is no Glk/ncurses/tty to hang
+# on and no game is loaded. It is a first-class build target (configure +
+# make), so it is always rebuilt from the current core -- the #processed
+# version stamp can never go stale the way a prebuilt cjacl does.
 #
 # Each package is a zip (flat entries) of the game's release .j2 plus its
 # .blorb, if any. The app imports it via "Open in JACL" and unpacks it.
@@ -14,11 +20,12 @@ set -e
 
 projects="${1:-../projects}"
 out="${2:-$projects/jaclgames}"
-cjacl="${3:-cjacl}"   # resolved from PATH (the deploy box installs it to /usr/local/bin)
+jpp="${3:-jpp}"   # resolved from PATH (make install puts it in /usr/local/bin)
 
-if ! command -v "$cjacl" >/dev/null 2>&1; then
-    echo "build-jaclgames: console interpreter '$cjacl' not found in PATH." >&2
-    echo "  It builds the release .j2 files; install cjacl or pass its path as arg 3." >&2
+if ! command -v "$jpp" >/dev/null 2>&1; then
+    echo "build-jaclgames: preprocessor '$jpp' not found in PATH." >&2
+    echo "  It writes the release .j2 files; run 'make jpp' / 'make install'" >&2
+    echo "  or pass the path to the jpp binary as arg 3." >&2
     exit 1
 fi
 
@@ -30,9 +37,11 @@ for game in "$projects"/*.jacl; do
 
     name=$(basename "$game" .jacl)
 
-    # Build the release (debug-free, obfuscated) .j2 -- written to the temp
-    # dir beside the game source.
-    "$cjacl" "$game" -release </dev/null >/dev/null 2>&1 || true
+    # Preprocess the release (debug-free, obfuscated) .j2 -- written to the
+    # temp dir beside the game source. jpp prints the output path on stdout;
+    # let its stderr through so a real failure is visible (the no-.j2 check
+    # below then skips the game cleanly).
+    "$jpp" "$game" -release >/dev/null || true
     j2="$projects/temp/$name.j2"
     if [ ! -f "$j2" ]; then
         echo "  skip $name (no .j2 produced)"

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -28,6 +28,14 @@ all: $(BUILD_TARGETS)
 bjorb: bjorb.c
 	$(CC) $(CFLAGS) -o bjorb bjorb.c
 
+# Jpp target (standalone JACL preprocessor utility). Shares the real
+# preprocessing engine (jpp.c) but links no Glk library -- it only needs
+# glk.h from $(GLKTERM_DIR) for the shared type declarations, never opens
+# a window or a terminal. Built fresh, so its #processed version stamp is
+# always current. Used by etc/build-jaclgames.sh to make release .j2s.
+jpp: jppmain.c jpp.c
+	$(CC) $(CFLAGS) -DGLK jppmain.c jpp.c -I$(GLKTERM_DIR) -o jpp
+
 # Jacl target (GlkTerm console, requires ncurses)
 jacl: libglkterm.a
 	$(CC) $(CFLAGS) -DGLK jacl.c glk_startup.c $(COMMON_SRC) glk_saver.c -I$(GLKTERM_DIR) -L$(GLKTERM_DIR) -lglkterm -lm $(NCURSES_LIBS) -o jacl
@@ -108,7 +116,7 @@ apache: install
 	@cp -r ../guide/* /var/www/html/guide/
 	@echo "Building .jaclgame download packages for iPad..."
 	@mkdir -p /var/www/html/games
-	@sh ../etc/build-jaclgames.sh /usr/local/jacl/projects /var/www/html/games cjacl || true
+	@sh ../etc/build-jaclgames.sh /usr/local/jacl/projects /var/www/html/games "$$PWD/jpp" || true
 	@echo "Building landing-page index.html..."
 	@sh ../etc/gen-landing.sh /usr/local/jacl/projects /var/www/html/games > /var/www/html/index.html
 	@echo "Installing Apache configuration..."

--- a/src/configure
+++ b/src/configure
@@ -4033,8 +4033,8 @@ fi
 # -----------------------------------------------------------
 # Build the target list
 # -----------------------------------------------------------
-BUILD_TARGETS="bjorb cgijacl"
-INSTALL_CMDS="cp bjorb cgijacl ../bin/; install bjorb cgijacl /usr/local/bin/"
+BUILD_TARGETS="bjorb jpp cgijacl"
+INSTALL_CMDS="cp bjorb jpp cgijacl ../bin/; install bjorb jpp cgijacl /usr/local/bin/"
 
 if test "$HAVE_NCURSES" = "yes"; then
     BUILD_TARGETS="$BUILD_TARGETS jacl"
@@ -5174,6 +5174,7 @@ echo "JACL $PACKAGE_VERSION configured."
 echo ""
 echo "  Interpreters to build:"
 echo "    bjorb         yes (utility)"
+echo "    jpp           yes (preprocessor utility)"
 echo "    cgijacl       yes (CGI web)"
 if test "$HAVE_NCURSES" = "yes"; then
 echo "    jacl          yes (GlkTerm console)"

--- a/src/configure.ac
+++ b/src/configure.ac
@@ -229,8 +229,8 @@ fi
 # -----------------------------------------------------------
 # Build the target list
 # -----------------------------------------------------------
-BUILD_TARGETS="bjorb cgijacl"
-INSTALL_CMDS="cp bjorb cgijacl ../bin/; install bjorb cgijacl /usr/local/bin/"
+BUILD_TARGETS="bjorb jpp cgijacl"
+INSTALL_CMDS="cp bjorb jpp cgijacl ../bin/; install bjorb jpp cgijacl /usr/local/bin/"
 
 if test "$HAVE_NCURSES" = "yes"; then
     BUILD_TARGETS="$BUILD_TARGETS jacl"
@@ -259,6 +259,7 @@ echo "JACL $PACKAGE_VERSION configured."
 echo ""
 echo "  Interpreters to build:"
 echo "    bjorb         yes (utility)"
+echo "    jpp           yes (preprocessor utility)"
 echo "    cgijacl       yes (CGI web)"
 if test "$HAVE_NCURSES" = "yes"; then
 echo "    jacl          yes (GlkTerm console)"

--- a/src/jppmain.c
+++ b/src/jppmain.c
@@ -1,0 +1,210 @@
+/* jppmain.c --- Standalone JACL preprocessor CLI.
+ * (C) 2026 Stuart Allen, distribute and use
+ * according to GNU GPL, see file COPYING for details.
+ *
+ * Runs *only* the preprocessing pass (jpp.c): inline every #include,
+ * strip leading/trailing whitespace, stamp "#processed:VERSION" and --
+ * with -release -- drop the #debug libraries and XOR-obfuscate from the
+ * first non-comment line. The result is written to <prefix>.j2 in the
+ * temp directory beside the game (or, failing that, the current
+ * directory) and the program exits.
+ *
+ * Unlike driving a full interpreter (cjacl/jacl) just for its start-up
+ * side effect, this tool links no Glk library: it never opens a window,
+ * never initialises ncurses, never loads or runs the game. So it needs
+ * no terminal, can't hang waiting on one, and emits no escape codes --
+ * the right tool for batch-building release .j2 download packages (see
+ * etc/build-jaclgames.sh).
+ *
+ * Because it is built from the current core, INTERPRETER_VERSION is
+ * compiled straight into the shared jpp.c -- the "#processed" stamp is
+ * always correct and never goes stale the way a prebuilt cjacl does.
+ *
+ * Like decrypt.c, this standalone tool carries its own copies of the
+ * small, stable helpers (create_paths / stripwhite / jacl_obfuscate)
+ * rather than linking utils.o -- utils.o references execute(),
+ * integer_resolve() and friends, which would drag in the whole
+ * interpreter. The preprocessing *engine* (jpp.c) is shared, so the .j2
+ * format can never drift from what the interpreter expects.
+ */
+
+#include "jacl.h"
+#include "language.h"
+#include "types.h"
+#include "prototypes.h"
+#include <string.h>
+
+/* --- The global buffers jpp.c reads and writes. These mirror the
+ *     canonical declarations in jacl.c; jpp.c uses snprintf with
+ *     explicit caps, so matching the sizes keeps every write in
+ *     bounds. text_buffer normally lives in encapsulate.c, but we do
+ *     not link that unit (it pulls in the interpreter), so it is
+ *     defined here as the sole definition. --- */
+char            text_buffer[1024];
+char            temp_buffer[1024];
+char            error_buffer[1024];
+char            game_file[256] = "\0";
+char            game_path[256] = "\0";
+char            prefix[81] = "\0";
+char            processed_file[256] = "\0";
+char            include_directory[81] = "\0";
+char            temp_directory[81] = "\0";
+
+/* jpp.c owns `release`; -release flips it on. */
+extern short int release;
+
+static int jacl_whitespace(int character);
+
+int
+main(int argc, char *argv[])
+{
+	const char     *filename = NULL;
+	int             index;
+
+	/* Parse a single game-file argument plus optional flags. */
+	for (index = 1; index < argc; index++) {
+		if (!strcmp(argv[index], "-release")) {
+			release = TRUE;
+		} else if (!strcmp(argv[index], "-noencrypt")) {
+			/* Accepted for command-line parity with the interpreters.
+			 * Obfuscation is driven entirely by -release inside jpp.c,
+			 * so this flag is a no-op here. */
+		} else if (argv[index][0] == '-') {
+			fprintf(stderr, "%s: unknown option '%s'\n", argv[0], argv[index]);
+			return 1;
+		} else if (filename == NULL) {
+			filename = argv[index];
+		} else {
+			fprintf(stderr, "%s: only one game file may be given\n", argv[0]);
+			return 1;
+		}
+	}
+
+	if (filename == NULL) {
+		fprintf(stderr, "usage: %s <game.jacl> [-release] [-noencrypt]\n",
+			argc > 0 ? argv[0] : "jpp");
+		fprintf(stderr, "  Preprocesses a JACL source file into a self-contained .j2.\n");
+		fprintf(stderr, "  -release   drop #debug libraries and obfuscate the output\n");
+		return 1;
+	}
+
+	/* create_paths() strips the extension from its argument in place and
+	 * also writes temp_buffer in the no-directory case, exactly as the
+	 * interpreters call it with the global temp_buffer. Follow that
+	 * pattern: stage the filename there first. */
+	snprintf(temp_buffer, sizeof(temp_buffer), "%s", filename);
+	create_paths(temp_buffer);
+
+	if (jpp() == FALSE) {
+		fprintf(stderr, "%s: %s\n", argv[0],
+			error_buffer[0] ? error_buffer : "preprocessing failed");
+		return 1;
+	}
+
+	printf("%s\n", processed_file);
+	return 0;
+}
+
+/* --- Stable helpers duplicated from the runtime, as decrypt.c does.
+ *     create_paths here is trimmed to what preprocessing needs: it sets
+ *     game_file, game_path, prefix and defaults the include/temp dirs.
+ *     It deliberately omits the GLK-only walkthru/bookmark/blorb and the
+ *     data directory, none of which jpp.c touches. --- */
+void
+create_paths(char *full_path)
+{
+	int             i;
+	char           *last_slash;
+
+	/* Keep the full game-file name. */
+	strcpy(game_file, full_path);
+
+	last_slash = strrchr(full_path, DIR_SEPARATOR);
+
+	/* Strip the file extension (back to the last '.' before any slash). */
+	for (i = (int) strlen(full_path) - 1; i >= 0; i--) {
+		if (full_path[i] == DIR_SEPARATOR) {
+			break;
+		} else if (full_path[i] == '.') {
+			full_path[i] = 0;
+			break;
+		}
+	}
+
+	if (last_slash == (char *) NULL) {
+		/* Game is in the current directory: no path part. */
+		strcpy(prefix, full_path);
+		game_path[0] = 0;
+		snprintf(temp_buffer, 256, ".%c%s", DIR_SEPARATOR, game_file);
+		strncpy(game_file, temp_buffer, 255);
+		game_file[255] = 0;
+	} else {
+		/* Split into directory (with trailing slash) and bare prefix. */
+		last_slash++;
+		strcpy(prefix, last_slash);
+		*last_slash = '\0';
+		strcpy(game_path, full_path);
+	}
+
+	if (include_directory[0] == 0) {
+		snprintf(include_directory, 81, "%s%s", game_path, INCLUDE_DIR);
+	}
+
+	if (temp_directory[0] == 0) {
+		snprintf(temp_directory, 81, "%s%s", game_path, TEMP_DIR);
+	}
+}
+
+int
+jacl_whitespace(int character)
+{
+	/* Characters JACL treats as leading/trailing whitespace. */
+	switch (character) {
+		case ':':
+		case '\t':
+		case ' ':
+			return (TRUE);
+		default:
+			return (FALSE);
+	}
+}
+
+char *
+stripwhite(char *string)
+{
+	int             i;
+
+	while (jacl_whitespace(*string)) string++;
+
+	i = strlen(string) - 1;
+
+	while (i >= 0 && ((jacl_whitespace(*(string + i))) || *(string + i) == '\n' || *(string + i) == '\r')) i--;
+
+#ifdef _WIN32
+	i++;
+	*(string + i) = '\r';
+#endif
+	i++;
+	*(string + i) = '\n';
+	i++;
+	*(string + i) = '\0';
+
+	return string;
+}
+
+/* Same XOR-with-0xFF obfuscation as utils.c, stopping at the line
+ * break so jpp.c's fputs keeps the source line-delimited. */
+void
+jacl_obfuscate(char *string)
+{
+	int             index, length;
+
+	length = strlen(string);
+
+	for (index = 0; index < length; index++) {
+		if (string[index] == '\n' || string[index] == '\r') {
+			return;
+		}
+		string[index] = string[index] ^ 255;
+	}
+}


### PR DESCRIPTION
## Why

The iPad download packages (`make apache` → `build-jaclgames.sh`) need each published game's release `.j2`. Master currently builds those by driving a console interpreter, which is fragile:

- **`cjacl`** is *not* a `configure` build target, so the installed copy silently goes stale (this is what broke the live deploy — the `.j2`s were stamped by an old interpreter).
- **`jacl`** (GlkTerm) only preprocesses as a *side effect* of start-up: it then inits ncurses, paints the whole intro, runs the game, and only quits on stdin EOF — with a real risk of hanging when there's no terminal.

## What

A new first-class build target **`jpp`** that runs *only* the preprocessing pass: inline `#include`s, strip whitespace, stamp `#processed:VERSION`, and — with `-release` — drop the `#debug` libraries and obfuscate.

- **Shares the real engine** (`jpp.c`), so output is **byte-for-byte identical** to the interpreter's (verified on grail + dragon, release + includes/blorb).
- **Links no Glk library** — just `glk.h` for shared type declarations. Never opens a window or terminal, so it can't hang and emits no escape codes.
- **Always fresh:** built from the current core, so the `#processed` version stamp can never go stale the way a prebuilt `cjacl` does.
- Like `decrypt.c`, carries its own copies of the small stable helpers (`create_paths`/`stripwhite`/`jacl_obfuscate`) rather than linking `utils.o`, which would drag in the whole interpreter.

`build-jaclgames.sh` and the Makefile `apache` target now use `jpp` instead of `cjacl`.

## Verification

- `./configure` lists `jpp`; `make jpp` builds a 35 KB binary, no ncurses/glk linked.
- Output byte-identical to the `jacl` interpreter's `.j2` for the same input.
- Full deploy step (`build-jaclgames.sh`) produces all 16 `.jaclgame` packages, each containing the correct processed/obfuscated `.j2` (+ blorb where present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)