### PR TITLE
iPad: fix multi-load crash + "Get more games" link

### DIFF
--- a/etc/build-jaclgames.sh
+++ b/etc/build-jaclgames.sh
@@ -54,6 +54,16 @@ for game in "$projects"/*.jacl; do
 
     name=$(basename "$game" .jacl)
 
+    # Skip web-only games (constant game_web_only true) -- they need the web
+    # HTML interface (e.g. blackjacl renders its cards in HTML), so they don't
+    # run on the Glk-based iPad/console interpreters. Don't build a package, and
+    # drop any stale one so it disappears from the iPad downloads tab.
+    if grep -qE '^constant[[:space:]]+game_web_only[[:space:]]+true' "$game"; then
+        rm -f "$out/$name.jaclgame"
+        echo "  skip $name (web-only)"
+        continue
+    fi
+
     # Preprocess the release (debug-free, obfuscated) .j2 -- written to the
     # temp dir beside the game source. jpp prints the output path on stdout;
     # let its stderr through so a real failure is visible (the no-.j2 check

--- a/etc/gen-landing.sh
+++ b/etc/gen-landing.sh
@@ -7,8 +7,9 @@
 # GAMES_DIR:    where built .jaclgame packages live; the "Get it for iPad"
 #               tab lists only games that have one.
 #
-# Two CSS-only tabs (no JavaScript): "Play Online" (fcgijacl links) and
-# "Get it for iPad" (.jaclgame downloads).
+# Two CSS-only tabs: "Play Online" (fcgijacl links) and "Get it for iPad"
+# (.jaclgame downloads). Tab switching is pure CSS; a small script at the end
+# adds one enhancement -- opening the page as .../#get selects the iPad tab.
 
 projects="${1:-../projects}"
 games="${2:-$projects/jaclgames}"
@@ -127,5 +128,14 @@ cat <<'TAIL'
     </div>
   </main>
   <footer>Served by JACL. Online games run via the fcgijacl interpreter. <a href="/guide/">Read the Guide</a> to write your own. &middot; <a href="/privacy.html">Privacy</a></footer>
+  <script>
+    /* Deep-link: opening the page as .../#get (e.g. the JACL iPad app's
+       "Get more games" link) selects the "Get it for iPad" tab directly.
+       Pure enhancement -- without JS the page just shows the default tab. */
+    if (location.hash === '#get') {
+      var g = document.getElementById('tab-get');
+      if (g) g.checked = true;
+    }
+  </script>
 </body></html>
 TAIL

--- a/ios/JACL/SettingsView.swift
+++ b/ios/JACL/SettingsView.swift
@@ -2,13 +2,19 @@
 //  The app's Settings sheet, reached from the gear button on the shelf.
 //
 //  Deliberately minimal: the interpreter has no runtime options on iOS (no
-//  sound, no accounts). Its main job is the App-Store-required in-app link to
-//  the hosted privacy policy, plus a short About section.
+//  sound, no accounts). It offers a "Get more games" link to the website's
+//  iPad downloads, the App-Store-required privacy-policy link, and a short
+//  About section. These are plain Links that hand off to Safari -- the app
+//  itself makes no network connections.
 
 import SwiftUI
 
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
+
+    /// Opens the site's "Get it for iPad" downloads tab directly -- the #get
+    /// fragment selects that tab. A plain Safari hand-off; no in-app network.
+    private static let getMoreURL = URL(string: "https://jacl.dangarmarine.com.au/#get")!
 
     /// Same policy hosted for the App Store Connect "Privacy Policy URL" field.
     private static let privacyURL = URL(string: "https://jacl.dangarmarine.com.au/privacy.html")!
@@ -23,6 +29,16 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
+                Section {
+                    Link(destination: Self.getMoreURL) {
+                        Label("Get more games", systemImage: "arrow.down.circle")
+                    }
+                } footer: {
+                    Text("Browse the iPad games on jacl.dangarmarine.com.au. Tap "
+                       + "a game to download it, then choose \u{201C}Open in "
+                       + "JACL\u{201D} to install it.")
+                }
+
                 Section {
                     Link(destination: Self.privacyURL) {
                         Label("Privacy Policy", systemImage: "hand.raised")

--- a/projects/blackjacl.jacl
+++ b/projects/blackjacl.jacl
@@ -9,6 +9,7 @@ constant game_publish     true
 constant game_title       "Blackjacl"
 constant game_author      "Stuart Allen"
 constant game_version     1
+constant game_web_only    true
 constant ifid             "JACL-106"
 integer INDEX
 integer COUNTER

--- a/src/loader.c
+++ b/src/loader.c
@@ -78,6 +78,16 @@ read_gamefile()
 
     char            function_name[81];
 
+    /* iOS (and long-lived FastCGI) reuse the process across games, so the
+     * previous game's tables are still live on entry. read_gamefile() assumes
+     * empty tables -- create_string/create_cstring/create_attribute/... all
+     * dereference a "current" tail pointer once the list is non-empty, which
+     * crashes when that pointer is stale from a prior game. Tear down any
+     * prior game's data first. A no-op on the very first load (all tables
+     * NULL, objects == 0); this is the per-load equivalent of the
+     * restart_game() the desktop/web paths already run between games. */
+    clear_game_data();
+
     // CREATE SOME SYSTEM VARIABLES
 
     // THIS IS USED BY JACL FUNCTIONS TO PASS STRING VALUES BACK
@@ -1277,8 +1287,14 @@ legal_label_check(const char *word, int line, int type)
     return (FALSE);
 }
 
+/* Free every game data table and reset its head to NULL, leaving the
+ * interpreter in the same clean state as a freshly-started process. Called at
+ * the top of read_gamefile() so each load starts fresh, and indirectly by
+ * restart_game(). Safe to call before any game has loaded (all tables NULL,
+ * objects == 0). Must NOT touch runtime-only state such as SOUND_SUPPORTED or
+ * the volume cintegers -- those don't exist on a fresh process. */
 void
-restart_game()
+clear_game_data()
 {
     int             index;
 
@@ -1297,21 +1313,6 @@ restart_game()
     struct cinteger_type *previous_cinteger;
     struct filter_type *current_filter;
     struct filter_type *previous_filter;
-
-#ifdef GLK
-    if (SOUND_SUPPORTED->value) {
-        /* STOP ALL SOUNDS AND SET VOLUMES BACK TO 100% */
-        for (index = 0; index < 4; index++) {
-            glk_schannel_stop(sound_channel[index]);
-            glk_schannel_set_volume(sound_channel[index], 65535);
-
-            /* STORE A COPY OF THE CURRENT VOLUME FOR ACCESS
-             * FROM JACL CODE */
-            sprintf(temp_buffer, "volume[%d]", index);
-            cinteger_resolve(temp_buffer)->value = 100;
-        }
-    }
-#endif
 
     /* FREE ALL OBJECTS */
     for (index = 1; index <= objects; index++) {
@@ -1480,7 +1481,32 @@ restart_game()
 
     free_from(grammar_table);
     grammar_table = NULL;
+}
 
+void
+restart_game()
+{
+#ifdef GLK
+    int             index;
+
+    /* Stop any playing sounds and reset volumes before the running game is
+     * torn down. Kept here rather than in clear_game_data() because it reads
+     * SOUND_SUPPORTED and the volume cintegers, which only exist once a game
+     * has loaded -- clear_game_data() must stay safe on a fresh process. */
+    if (SOUND_SUPPORTED->value) {
+        for (index = 0; index < 4; index++) {
+            glk_schannel_stop(sound_channel[index]);
+            glk_schannel_set_volume(sound_channel[index], 65535);
+
+            /* STORE A COPY OF THE CURRENT VOLUME FOR ACCESS FROM JACL CODE */
+            sprintf(temp_buffer, "volume[%d]", index);
+            cinteger_resolve(temp_buffer)->value = 100;
+        }
+    }
+#endif
+
+    /* read_gamefile() now clears all game data first, so this reloads from a
+     * clean state -- the teardown that used to live inline here. */
     if (read_gamefile()) {
         log_error("Game reload failed due to errors, keeping previous state.", PLUS_STDERR);
     }

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -119,6 +119,7 @@ void clear_cstring(const char *name);
 void add_cinteger(const char *name, int value);
 void clear_cinteger(const char *name);
 void restart_game(void);
+void clear_game_data(void);
 int read_gamefile(void);
 void unkvalerr(int line, int wordno);
 void totalerrs(int errors);


### PR DESCRIPTION
Two changes from on-device testing.

## 1. Fix the iOS multi-game crash (`loader.c`) — the important one

Loading a second game crashed with `EXC_BAD_ACCESS` at `0x430` in `create_cstring()` (`read_gamefile`). Root cause: `read_gamefile()` assumes it starts from **empty tables** — `create_string`/`create_cstring`/`create_attribute`/… all dereference a "current" tail pointer once the list is non-empty. That holds on desktop (one game per process) and web (which calls `restart_game()` between games), but **not on iOS**, where the long-lived process reuses tables across games. The second load ran with the first game's tables still live and a stale `current_cstring` → NULL deref (`0x430` = offset of `next_string` in `struct string_type`).

**Fix:** extract `restart_game()`'s table teardown into `clear_game_data()` and call it at the top of `read_gamefile()`, so every load starts clean. No-op on the first load (tables NULL, `objects == 0`). The sound-stop stays in `restart_game()` (it reads `SOUND_SUPPORTED`, which only exists post-load).

**Verified:** `cjacl` restart — which reloads on *populated* tables, the same path — frees + reloads with no crash; "examine me" works after; desktop + iOS builds succeed. It also hardens long-lived FastCGI the same way.

## 2. "Get more games" link + web-only filter

- A prominent **"Get more games"** row in the app's Settings → opens the website's iPad downloads tab directly (`#get` deep-link). Plain Safari hand-off, so **the app still makes no network calls** — no privacy-policy change.
- Mark web-only games with `constant game_web_only true` (blackjacl renders cards in HTML). `build-jaclgames.sh` skips them, so they don't appear in the iPad downloads (still on Play-Online). "Works on console" is the general rule; only HTML-dependent exceptions are flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)