### PR TITLE
iOS: fix game-swap (image cache + terp gate), console prompt, dark shelf

### DIFF
--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -62,6 +62,15 @@ struct GameView: View {
                 bridge.start(gamePath: gamePath, size: geo.size)
             }
             .onDisappear {
+                #if DEBUG
+                // `-noOnDisappearStop` reproduces the real-tap failure (where
+                // this back-pop onDisappear doesn't fire) so the force-stop in
+                // GlkBridge.start() can be verified as the actual safety net.
+                if ProcessInfo.processInfo.arguments.contains("-noOnDisappearStop") {
+                    NSLog("JDBG onDisappear stop SUPPRESSED (test)")
+                    return
+                }
+                #endif
                 // Leaving the game (back to the shelf): stop this terp so its
                 // thread exits and frees the shared JACL/RemGlk globals before
                 // another game starts. Without this, swapping games leaves two

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -24,6 +24,12 @@ final class BlorbImageCache {
         store[num] = img
         return img
     }
+
+    /// Drop all cached images. MUST be called when switching games: the cache
+    /// is keyed by blorb resource number only, and every game numbers its title
+    /// image #1 etc., so without this the new game's "draw image 1" returns the
+    /// PREVIOUS game's cached image (e.g. grail showing the Down Dragon banner).
+    func clear() { store.removeAll() }
 }
 
 struct GameView: View {

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -61,22 +61,11 @@ struct GameView: View {
                 inputBar
             }
             .onAppear {
-                NSLog("JDBG GameView.onAppear started=%@ path=%@",
-                      String(started), (gamePath as NSString).lastPathComponent)
                 guard !started else { return }
                 started = true
                 bridge.start(gamePath: gamePath, size: geo.size)
             }
             .onDisappear {
-                #if DEBUG
-                // `-noOnDisappearStop` reproduces the real-tap failure (where
-                // this back-pop onDisappear doesn't fire) so the force-stop in
-                // GlkBridge.start() can be verified as the actual safety net.
-                if ProcessInfo.processInfo.arguments.contains("-noOnDisappearStop") {
-                    NSLog("JDBG onDisappear stop SUPPRESSED (test)")
-                    return
-                }
-                #endif
                 // Leaving the game (back to the shelf): stop this terp so its
                 // thread exits and frees the shared JACL/RemGlk globals before
                 // another game starts. Without this, swapping games leaves two

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -130,7 +130,19 @@ struct GameView: View {
     // MARK: Buffer window (scrolling transcript), auto-scrolled to bottom
 
     private func bufferView(id: Int) -> some View {
-        let paras = bridge.buffers[id] ?? []
+        var paras = bridge.buffers[id] ?? []
+        // While the game waits for a command, JACL has already written its bare
+        // prompt ("> ") as the trailing paragraph. Hide it: the input bar below
+        // is the live prompt, and the command is echoed back ("> look") on
+        // submit. Only drop a genuinely-short trailing line, so real output (or
+        // an already-echoed "> look") is never removed.
+        if bridge.pendingInput?.type == "line",
+           let last = paras.last,
+           last.spans.allSatisfy({ $0.image == nil }),
+           last.spans.map(\.text).joined()
+               .trimmingCharacters(in: .whitespacesAndNewlines).count <= 2 {
+            paras.removeLast()
+        }
         return ScrollViewReader { proxy in
             ScrollView {
                 // LazyVStack, not VStack: a long transcript in a plain VStack
@@ -158,17 +170,22 @@ struct GameView: View {
     // MARK: Input
 
     @ViewBuilder private var inputBar: some View {
-        if let req = bridge.pendingInput, req.type == "line" {
-            HStack {
-                TextField("…", text: $inputText)
-                    .textFieldStyle(.roundedBorder)
+        if bridge.pendingInput?.type == "line" {
+            // Console-style prompt: you type beside a ">", and the command is
+            // echoed into the transcript on submit (the bare ">" there is hidden
+            // by bufferView until then).
+            HStack(spacing: 6) {
+                Text(">").foregroundColor(.secondary)
+                TextField("", text: $inputText)
+                    .textFieldStyle(.plain)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .focused($inputFocused)
                     .onSubmit(submit)
                 Button("Enter", action: submit)
             }
-            .padding(8)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
         } else if bridge.pendingInput?.type == "char" {
             // A "press any key" / "[MORE]" pause. Rare now that the buffer is
             // reported tall, but handle it so the game can't get stuck.

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -60,12 +60,27 @@ final class GlkBridge: ObservableObject {
     // (the init event would never reach the terp -> blank screen / deadlock).
     private let writerQueue = DispatchQueue(label: "jacl.remglk.writer")
 
+    /// The terp that currently owns the shared stdin/stdout. Only one may run
+    /// at a time; starting a new game force-stops this one first.
+    static weak var active: GlkBridge?
+
     // MARK: Lifecycle
 
     /// Launch `gamePath` (an absolute .j2 path in the sandbox) and send the
     /// initial metrics for a display of `size` points.
     func start(gamePath: String, size: CGSize) {
         NSLog("JDBG GlkBridge.start path=%@", (gamePath as NSString).lastPathComponent)
+        // Force-stop whatever terp was running before this one. GameView's
+        // onDisappear normally does it, but that's unreliable on a navigation
+        // pop (the view lives inside a GeometryReader), which would leave the
+        // previous game's terp alive to hijack this game's shared stdin/stdout
+        // -- "running grail but showing dragon". The C-side gate then makes this
+        // terp wait until that one has actually exited.
+        if let prev = GlkBridge.active, prev !== self {
+            NSLog("JDBG GlkBridge.start force-stopping previous terp")
+            prev.stop()
+        }
+        GlkBridge.active = self
         var fds: [Int32] = [0, 0]
         guard socketpair(AF_UNIX, SOCK_STREAM, 0, &fds) == 0 else {
             NSLog("GlkBridge: socketpair failed")

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -64,12 +64,20 @@ final class GlkBridge: ObservableObject {
     /// at a time; starting a new game force-stops this one first.
     static weak var active: GlkBridge?
 
+    /// The game this bridge is running (for JDBG logging).
+    private var gameLabel = "?"
+
     // MARK: Lifecycle
 
     /// Launch `gamePath` (an absolute .j2 path in the sandbox) and send the
     /// initial metrics for a display of `size` points.
     func start(gamePath: String, size: CGSize) {
-        NSLog("JDBG GlkBridge.start path=%@", (gamePath as NSString).lastPathComponent)
+        gameLabel = (gamePath as NSString).lastPathComponent
+        NSLog("JDBG GlkBridge.start path=%@", gameLabel)
+        // Drop the previous game's cached blorb images -- the cache is keyed by
+        // resource number, so this game's image 1 would otherwise show the last
+        // game's image 1 (grail rendering the Down Dragon banner).
+        BlorbImageCache.shared.clear()
         // Force-stop whatever terp was running before this one. GameView's
         // onDisappear normally does it, but that's unreliable on a navigation
         // pop (the view lives inside a GeometryReader), which would leave the
@@ -211,6 +219,13 @@ final class GlkBridge: ObservableObject {
             return
         }
         if let gen = update.gen { generation = gen }
+
+        let snippet = (update.content ?? []).flatMap { c -> [String] in
+            ((c.text ?? []).flatMap { ($0.content ?? []).compactMap { $0.text } })
+            + ((c.lines ?? []).flatMap { ($0.content ?? []).compactMap { $0.text } })
+        }.joined(separator: " ")
+        NSLog("JDBG apply bridge=%@ wins=%d txt='%@'", gameLabel,
+              update.windows?.count ?? -1, String(snippet.prefix(70)))
 
         if let ws = update.windows {
             windows = ws

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -64,16 +64,11 @@ final class GlkBridge: ObservableObject {
     /// at a time; starting a new game force-stops this one first.
     static weak var active: GlkBridge?
 
-    /// The game this bridge is running (for JDBG logging).
-    private var gameLabel = "?"
-
     // MARK: Lifecycle
 
     /// Launch `gamePath` (an absolute .j2 path in the sandbox) and send the
     /// initial metrics for a display of `size` points.
     func start(gamePath: String, size: CGSize) {
-        gameLabel = (gamePath as NSString).lastPathComponent
-        NSLog("JDBG GlkBridge.start path=%@", gameLabel)
         // Drop the previous game's cached blorb images -- the cache is keyed by
         // resource number, so this game's image 1 would otherwise show the last
         // game's image 1 (grail rendering the Down Dragon banner).
@@ -85,7 +80,6 @@ final class GlkBridge: ObservableObject {
         // -- "running grail but showing dragon". The C-side gate then makes this
         // terp wait until that one has actually exited.
         if let prev = GlkBridge.active, prev !== self {
-            NSLog("JDBG GlkBridge.start force-stopping previous terp")
             prev.stop()
         }
         GlkBridge.active = self
@@ -120,7 +114,6 @@ final class GlkBridge: ObservableObject {
     /// which is only safe because the previous terp has been stopped first.
     func stop() {
         let fd = appFD
-        NSLog("JDBG GlkBridge.stop appFD=%d", fd)
         guard fd >= 0 else { return }
         appFD = -1
         shutdown(fd, SHUT_RDWR)
@@ -219,13 +212,6 @@ final class GlkBridge: ObservableObject {
             return
         }
         if let gen = update.gen { generation = gen }
-
-        let snippet = (update.content ?? []).flatMap { c -> [String] in
-            ((c.text ?? []).flatMap { ($0.content ?? []).compactMap { $0.text } })
-            + ((c.lines ?? []).flatMap { ($0.content ?? []).compactMap { $0.text } })
-        }.joined(separator: " ")
-        NSLog("JDBG apply bridge=%@ wins=%d txt='%@'", gameLabel,
-              update.windows?.count ?? -1, String(snippet.prefix(70)))
 
         if let ws = update.windows {
             windows = ws

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -175,24 +175,21 @@ struct GameShelfView: View {
     /// go back, open another" without a human tapping.
     private func runSwapTestIfRequested() {
         guard ProcessInfo.processInfo.arguments.contains("-swaptest"), games.count >= 2 else { return }
-        // Alternate the two games several times, popping to the shelf between
-        // each, to confirm every swap loads the *right* game (not the first one
-        // again) and that each previous terp exits (no accumulation/slowdown).
-        let sequence = [games[0], games[1], games[0], games[1]]
-        func step(_ i: Int) {
-            guard i < sequence.count else {
-                NSLog("JDBG SWAPTEST done; exiting")
-                exit(0)   // ends --console-pipe so the captured trace closes
-            }
-            NSLog("JDBG SWAPTEST push #%d %@", i + 1, sequence[i].title)
-            navPath = [sequence[i]]
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-                NSLog("JDBG SWAPTEST pop")
-                navPath = []
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { step(i + 1) }
+        // Reproduce the failing swap -- dragon, back, grail -- then SETTLE on
+        // grail (no exit) so a screenshot can confirm grail shows grail's title
+        // image, not the cached Down Dragon banner.
+        let dragon = games.first { $0.url.lastPathComponent.hasPrefix("dragon") } ?? games[0]
+        let grail  = games.first { $0.url.lastPathComponent.hasPrefix("grail") }  ?? games[1]
+        NSLog("JDBG SWAPTEST push dragon")
+        navPath = [dragon]
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+            NSLog("JDBG SWAPTEST pop")
+            navPath = []
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                NSLog("JDBG SWAPTEST push grail (settling for screenshot)")
+                navPath = [grail]
             }
         }
-        step(0)
     }
     #endif
 }

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -48,6 +48,7 @@ struct JACLApp: App {
 struct GameShelfView: View {
     @State private var games: [Game] = []
     @State private var loaded = false
+    @State private var navPath: [Game] = []
     @State private var importing = false
     @State private var showingSettings = false
 
@@ -65,7 +66,7 @@ struct GameShelfView: View {
     }()
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navPath) {
             Group {
                 if !loaded {
                     ProgressView("Loading…")
@@ -160,9 +161,40 @@ struct GameShelfView: View {
                 }.value
                 games = result
                 loaded = true
+                #if DEBUG
+                runSwapTestIfRequested()
+                #endif
             }
         }
     }
+
+    #if DEBUG
+    /// `simctl launch … -swaptest`: drive a game swap headlessly so the JDBG
+    /// trace can be read off the Simulator console. Push games[0], wait, pop
+    /// back to the shelf, then push games[1] -- reproducing "open one game,
+    /// go back, open another" without a human tapping.
+    private func runSwapTestIfRequested() {
+        guard ProcessInfo.processInfo.arguments.contains("-swaptest"), games.count >= 2 else { return }
+        // Alternate the two games several times, popping to the shelf between
+        // each, to confirm every swap loads the *right* game (not the first one
+        // again) and that each previous terp exits (no accumulation/slowdown).
+        let sequence = [games[0], games[1], games[0], games[1]]
+        func step(_ i: Int) {
+            guard i < sequence.count else {
+                NSLog("JDBG SWAPTEST done; exiting")
+                exit(0)   // ends --console-pipe so the captured trace closes
+            }
+            NSLog("JDBG SWAPTEST push #%d %@", i + 1, sequence[i].title)
+            navPath = [sequence[i]]
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
+                NSLog("JDBG SWAPTEST pop")
+                navPath = []
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { step(i + 1) }
+            }
+        }
+        step(0)
+    }
+    #endif
 }
 
 // MARK: - Sandbox game storage

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -99,9 +99,11 @@ struct GameShelfView: View {
                 // (which a low opacity over the light system background gives).
                 ZStack {
                     Color.black
+                    // Fit the square artwork to the width (full image, centred),
+                    // leaving black gaps above and below rather than cropping it.
                     Image("ShelfArtwork")
                         .resizable()
-                        .scaledToFill()
+                        .scaledToFit()
                         .opacity(0.55)
                     Color.black.opacity(0.4)
                 }

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -48,7 +48,6 @@ struct JACLApp: App {
 struct GameShelfView: View {
     @State private var games: [Game] = []
     @State private var loaded = false
-    @State private var navPath: [Game] = []
     @State private var importing = false
     @State private var showingSettings = false
 
@@ -66,7 +65,7 @@ struct GameShelfView: View {
     }()
 
     var body: some View {
-        NavigationStack(path: $navPath) {
+        NavigationStack {
             Group {
                 if !loaded {
                     ProgressView("Loading…")
@@ -161,37 +160,9 @@ struct GameShelfView: View {
                 }.value
                 games = result
                 loaded = true
-                #if DEBUG
-                runSwapTestIfRequested()
-                #endif
             }
         }
     }
-
-    #if DEBUG
-    /// `simctl launch … -swaptest`: drive a game swap headlessly so the JDBG
-    /// trace can be read off the Simulator console. Push games[0], wait, pop
-    /// back to the shelf, then push games[1] -- reproducing "open one game,
-    /// go back, open another" without a human tapping.
-    private func runSwapTestIfRequested() {
-        guard ProcessInfo.processInfo.arguments.contains("-swaptest"), games.count >= 2 else { return }
-        // Reproduce the failing swap -- dragon, back, grail -- then SETTLE on
-        // grail (no exit) so a screenshot can confirm grail shows grail's title
-        // image, not the cached Down Dragon banner.
-        let dragon = games.first { $0.url.lastPathComponent.hasPrefix("dragon") } ?? games[0]
-        let grail  = games.first { $0.url.lastPathComponent.hasPrefix("grail") }  ?? games[1]
-        NSLog("JDBG SWAPTEST push dragon")
-        navPath = [dragon]
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
-            NSLog("JDBG SWAPTEST pop")
-            navPath = []
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                NSLog("JDBG SWAPTEST push grail (settling for screenshot)")
-                navPath = [grail]
-            }
-        }
-    }
-    #endif
 }
 
 // MARK: - Sandbox game storage

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -86,18 +86,27 @@ struct GameShelfView: View {
                     }
                     .scrollContentBackground(.hidden)   // let the artwork show through
                     .navigationDestination(for: Game.self) { game in
+                        // Keep the in-game transcript on the light theme; only
+                        // the shelf goes dark for the watermark.
                         GameView(gamePath: game.url.path)
+                            .preferredColorScheme(.light)
                     }
                 }
             }
             .background {
-                // The app artwork as a muted watermark behind the shelf.
-                Image("ShelfArtwork")
-                    .resizable()
-                    .scaledToFill()
-                    .opacity(0.15)
-                    .ignoresSafeArea()
-                    .allowsHitTesting(false)
+                // App artwork as a dark, muted watermark behind the shelf: the
+                // full image dimmed under a black scrim, rather than a pale wash
+                // (which a low opacity over the light system background gives).
+                ZStack {
+                    Color.black
+                    Image("ShelfArtwork")
+                        .resizable()
+                        .scaledToFill()
+                        .opacity(0.55)
+                    Color.black.opacity(0.4)
+                }
+                .ignoresSafeArea()
+                .allowsHitTesting(false)
             }
             .navigationTitle("JACL v\(Self.interpreterVersion)")
             .safeAreaInset(edge: .bottom) {
@@ -162,6 +171,7 @@ struct GameShelfView: View {
                 loaded = true
             }
         }
+        .preferredColorScheme(.dark)   // light text on the dark shelf watermark
     }
 }
 

--- a/ios/ios_startup.c
+++ b/ios/ios_startup.c
@@ -86,9 +86,6 @@ jacl_ios_gamepath(void)
 int
 jacl_ios_prepare(const char *path)
 {
-	fprintf(stderr, "JDBG jacl_ios_prepare path=%s game_stream=%p\n",
-	        path ? path : "(null)", (void *)game_stream);
-
 	/* Idempotent: if we already opened a game stream, a second call (e.g.
 	 * the app calling us directly AND the backend running
 	 * glkunix_startup_code) is a no-op rather than a double-load. */

--- a/ios/jacl_bridge.c
+++ b/ios/jacl_bridge.c
@@ -63,14 +63,10 @@ void jacl_bridge_mark_terp_exited(void)
 	terp_live = 0;
 	pthread_cond_broadcast(&terp_gone);
 	pthread_mutex_unlock(&terp_gate);
-	fprintf(stderr, "JDBG terp gate: released\n");
 }
 
 int jacl_bridge_run(const char *gamepath, int io_fd)
 {
-	fprintf(stderr, "JDBG jacl_bridge_run gamepath=%s io_fd=%d\n",
-	        gamepath ? gamepath : "(null)", io_fd);
-
 	/* Wait for any previous terp to fully exit before claiming the shared
 	 * stdin/stdout below -- otherwise two terps race on the same fds and the
 	 * older one hijacks this game's window. Bounded so a stuck terp can't
@@ -80,10 +76,8 @@ int jacl_bridge_run(const char *gamepath, int io_fd)
 		struct timespec deadline;
 		clock_gettime(CLOCK_REALTIME, &deadline);
 		deadline.tv_sec += 3;
-		fprintf(stderr, "JDBG terp gate: waiting for previous terp\n");
 		while (terp_live) {
 			if (pthread_cond_timedwait(&terp_gone, &terp_gate, &deadline) != 0) {
-				fprintf(stderr, "JDBG terp gate: TIMEOUT, proceeding\n");
 				break;
 			}
 		}

--- a/ios/jacl_bridge.c
+++ b/ios/jacl_bridge.c
@@ -14,6 +14,8 @@
 
 #include <stdio.h>
 #include <unistd.h>
+#include <pthread.h>
+#include <time.h>
 #include "glk.h"
 #include "gi_blorb.h"
 #include "jacl_ios.h"
@@ -34,10 +36,60 @@ const char *jacl_interpreter_version(void)
     return buf;
 }
 
+/* ---- one-terp-at-a-time gate --------------------------------------------
+ *
+ * JACL + RemGlk keep all state in process globals and share the one pair of
+ * stdin/stdout the terp dup2()s its socket onto, so only ONE terp may run at a
+ * time. The terp ends via pthread_exit() (never returns; the app can't join a
+ * glk_exit), and the Swift onDisappear that closes the old socket is
+ * unreliable on a navigation pop -- so the previous game's terp can still be
+ * alive when the next starts. It then reads the NEW game's socket off the
+ * shared fd and renders the OLD game into the new window (the bug: "running
+ * grail but showing dragon").
+ *
+ * This gate closes the hole: jacl_bridge_mark_terp_exited() is called from
+ * every terp exit path (rgmisc.c glk_exit / fatal, rgwindow.c fast_exit), and
+ * jacl_bridge_run() blocks until the previous terp signals exit before it
+ * touches the shared stdio. The wait is bounded so a wedged terp can't hang
+ * the app. Combined with the Swift side force-stopping the previous terp when
+ * a new game starts, the old terp is guaranteed gone before the new one runs. */
+static pthread_mutex_t terp_gate = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t  terp_gone = PTHREAD_COND_INITIALIZER;
+static int             terp_live = 0;
+
+void jacl_bridge_mark_terp_exited(void)
+{
+	pthread_mutex_lock(&terp_gate);
+	terp_live = 0;
+	pthread_cond_broadcast(&terp_gone);
+	pthread_mutex_unlock(&terp_gate);
+	fprintf(stderr, "JDBG terp gate: released\n");
+}
+
 int jacl_bridge_run(const char *gamepath, int io_fd)
 {
 	fprintf(stderr, "JDBG jacl_bridge_run gamepath=%s io_fd=%d\n",
 	        gamepath ? gamepath : "(null)", io_fd);
+
+	/* Wait for any previous terp to fully exit before claiming the shared
+	 * stdin/stdout below -- otherwise two terps race on the same fds and the
+	 * older one hijacks this game's window. Bounded so a stuck terp can't
+	 * black-hole the app. */
+	pthread_mutex_lock(&terp_gate);
+	if (terp_live) {
+		struct timespec deadline;
+		clock_gettime(CLOCK_REALTIME, &deadline);
+		deadline.tv_sec += 3;
+		fprintf(stderr, "JDBG terp gate: waiting for previous terp\n");
+		while (terp_live) {
+			if (pthread_cond_timedwait(&terp_gone, &terp_gate, &deadline) != 0) {
+				fprintf(stderr, "JDBG terp gate: TIMEOUT, proceeding\n");
+				break;
+			}
+		}
+	}
+	terp_live = 1;
+	pthread_mutex_unlock(&terp_gate);
 
 	/* Tell the start-up shim which .j2 to open. glkunix_startup_code()
 	 * reads this back via ios_gamepath (see ios_startup.c). */

--- a/ios/jacl_bridge.h
+++ b/ios/jacl_bridge.h
@@ -38,6 +38,11 @@ const void *jacl_bridge_image(unsigned int num, unsigned int *len);
  * confirm at a glance which build is actually running. */
 const char *jacl_interpreter_version(void);
 
+/* Called from every terp exit path (glk_exit / fatal / fast_exit) just before
+ * pthread_exit(), to release the one-terp-at-a-time gate so the next game's
+ * jacl_bridge_run() may proceed. See jacl_bridge.c. */
+void jacl_bridge_mark_terp_exited(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ios/remglk/rgmisc.c
+++ b/ios/remglk/rgmisc.c
@@ -77,6 +77,7 @@ void glk_exit()
     /* The terp runs on a background thread; exit() would kill the whole app.
      * End just this thread -- GlkBridge sees the socket close and tears down.
      * Desktop sims don't define JACL_IOS_EMBED, so they exit() as before. */
+    fprintf(stderr, "JDBG terp_exit (glk_exit)\n");
     pthread_exit(NULL);
 #else
     exit(0);
@@ -198,6 +199,7 @@ void gli_display_error(char *msg)
     printf("\n"); /* blank line after stanza */
     fflush(stdout);
 #ifdef JACL_IOS_EMBED
+    fprintf(stderr, "JDBG terp_exit (fatal: %s)\n", msg ? msg : "?");
     pthread_exit(NULL);   /* a fatal ends the terp thread, not the whole app */
 #else
     exit(1);

--- a/ios/remglk/rgmisc.c
+++ b/ios/remglk/rgmisc.c
@@ -77,7 +77,6 @@ void glk_exit()
     /* The terp runs on a background thread; exit() would kill the whole app.
      * End just this thread -- GlkBridge sees the socket close and tears down.
      * Desktop sims don't define JACL_IOS_EMBED, so they exit() as before. */
-    fprintf(stderr, "JDBG terp_exit (glk_exit)\n");
     { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);
 #else
@@ -200,7 +199,6 @@ void gli_display_error(char *msg)
     printf("\n"); /* blank line after stanza */
     fflush(stdout);
 #ifdef JACL_IOS_EMBED
-    fprintf(stderr, "JDBG terp_exit (fatal: %s)\n", msg ? msg : "?");
     { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);   /* a fatal ends the terp thread, not the whole app */
 #else

--- a/ios/remglk/rgmisc.c
+++ b/ios/remglk/rgmisc.c
@@ -78,6 +78,7 @@ void glk_exit()
      * End just this thread -- GlkBridge sees the socket close and tears down.
      * Desktop sims don't define JACL_IOS_EMBED, so they exit() as before. */
     fprintf(stderr, "JDBG terp_exit (glk_exit)\n");
+    { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);
 #else
     exit(0);
@@ -200,6 +201,7 @@ void gli_display_error(char *msg)
     fflush(stdout);
 #ifdef JACL_IOS_EMBED
     fprintf(stderr, "JDBG terp_exit (fatal: %s)\n", msg ? msg : "?");
+    { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);   /* a fatal ends the terp thread, not the whole app */
 #else
     exit(1);

--- a/ios/remglk/rgwindow.c
+++ b/ios/remglk/rgwindow.c
@@ -86,6 +86,7 @@ void gli_fast_exit()
 
     gli_streams_close_all();
 #ifdef JACL_IOS_EMBED
+    fprintf(stderr, "JDBG terp_exit (fast_exit)\n");
     pthread_exit(NULL);   /* end the terp thread, not the whole app */
 #else
     exit(0);

--- a/ios/remglk/rgwindow.c
+++ b/ios/remglk/rgwindow.c
@@ -86,7 +86,6 @@ void gli_fast_exit()
 
     gli_streams_close_all();
 #ifdef JACL_IOS_EMBED
-    fprintf(stderr, "JDBG terp_exit (fast_exit)\n");
     { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);   /* end the terp thread, not the whole app */
 #else

--- a/ios/remglk/rgwindow.c
+++ b/ios/remglk/rgwindow.c
@@ -87,6 +87,7 @@ void gli_fast_exit()
     gli_streams_close_all();
 #ifdef JACL_IOS_EMBED
     fprintf(stderr, "JDBG terp_exit (fast_exit)\n");
+    { extern void jacl_bridge_mark_terp_exited(void); jacl_bridge_mark_terp_exited(); }
     pthread_exit(NULL);   /* end the terp thread, not the whole app */
 #else
     exit(0);


### PR DESCRIPTION
Follow-on work pushed to `fix/ipad-remglk-reentrancy` after PR #71 merged early (at the watermark commit). These are the commits that actually fixed the game-swap bug, plus UX polish and cleanup.

## The real swap fix
- **Blorb image cache** was the visible culprit: `BlorbImageCache` is keyed by resource number, so a second game's "draw image 1" returned the first game's cached title banner (grail showing the Down Dragon art). Cleared on each game start.
- **One-terp gate + force-stop**: the previous game's terp could outlive a navigation pop (unreliable `onDisappear` inside a `GeometryReader`) and hijack the new game's shared stdin/stdout. `GlkBridge.start()` force-stops the prior terp; a C-side gate blocks the new terp until the old one signals exit.

## UX
- Console-style `>` prompt: command echoes inline (`> look`), no dangling empty `>`.
- Dark, fitted shelf watermark (full square at width, black gaps top/bottom; light shelf text, game view stays light).

## Cleanup
- All `JDBG` logging and the `-swaptest` / `-noOnDisappearStop` debug scaffolding stripped; only the real fixes remain.

Verified on the iPad Pro 11" simulator: swap loads the correct game with the correct title image across repeated swaps; prompt and shelf render as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)