### PR TITLE
iPad: bundled dictionary lookup, copyable transcript, delete/update games

### DIFF
--- a/etc/build-jaclgames.sh
+++ b/etc/build-jaclgames.sh
@@ -36,8 +36,11 @@ fi
 # DEFLATE archive. Checking here turns a missing archiver into one clear
 # message instead of a set -e abort partway through the first game.
 #   mkzip ARCHIVE FILE...   (run from the directory holding FILEs)
+# Paths are preserved (NOT junked): the .j2/.blorb are bare names at the root,
+# but a bundled dictionary lives at data/<lang>_words.csv and must keep that
+# prefix so the interpreter finds it under the game's data/ dir.
 if command -v zip >/dev/null 2>&1; then
-    mkzip() { zip -j -q "$@"; }
+    mkzip() { zip -q -X "$@"; }
 elif command -v python3 >/dev/null 2>&1; then
     mkzip() { python3 -m zipfile -c "$@"; }
 else
@@ -79,15 +82,29 @@ for game in "$projects"/*.jacl; do
     rm -f "$pkg"
     tmp=$(mktemp -d)
     cp "$j2" "$tmp/$name.j2"
+    files="$name.j2"
     if [ -f "$projects/$name.blorb" ]; then
         cp "$projects/$name.blorb" "$tmp/$name.blorb"
-        ( cd "$tmp" && mkzip "$name.jaclgame" "$name.j2" "$name.blorb" )
-    else
-        ( cd "$tmp" && mkzip "$name.jaclgame" "$name.j2" )
+        files="$files $name.blorb"
     fi
+
+    # Bundle the matching language dictionary for click-to-define. A game that
+    # includes <lang>_verbs.library runs `iterate "<lang>_words.csv"`, which the
+    # interpreter opens under the game's data/ dir -- so package the CSV at
+    # data/<lang>_words.csv. (french / german / spanish / indonesian.)
+    for lang in french german spanish indonesian; do
+        if grep -qE "#include[[:space:]]+\"?${lang}_verbs\.library" "$game" \
+           && [ -f "$projects/data/${lang}_words.csv" ]; then
+            mkdir -p "$tmp/data"
+            cp "$projects/data/${lang}_words.csv" "$tmp/data/${lang}_words.csv"
+            files="$files data/${lang}_words.csv"
+        fi
+    done
+
+    ( cd "$tmp" && mkzip "$name.jaclgame" $files )
     mv "$tmp/$name.jaclgame" "$pkg"
     rm -rf "$tmp"
     n=$((n + 1))
-    echo "  $name.jaclgame"
+    echo "  $name.jaclgame${files#$name.j2}"
 done
 echo "build-jaclgames: $n package(s) in $out"

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -38,6 +38,9 @@ struct GameView: View {
     @StateObject private var bridge = GlkBridge()
     @State private var inputText = ""
     @State private var started = false
+    /// True if a `*_words.csv` dictionary is bundled next to this game, which
+    /// enables tap-a-word lookup. Computed once on appear.
+    @State private var hasDictionary = false
     @FocusState private var inputFocused: Bool
 
     // DEBUG-only scripted input (via `-autocommands "no;look;…"`), used to
@@ -63,6 +66,10 @@ struct GameView: View {
             .onAppear {
                 guard !started else { return }
                 started = true
+                // A dictionary lives at <gameDir>/data/<lang>_words.csv.
+                let dataDir = (gamePath as NSString).deletingLastPathComponent + "/data"
+                hasDictionary = ((try? FileManager.default.contentsOfDirectory(atPath: dataDir)) ?? [])
+                    .contains { $0.hasSuffix("_words.csv") }
                 bridge.start(gamePath: gamePath, size: geo.size)
             }
             .onDisappear {
@@ -132,28 +139,15 @@ struct GameView: View {
                .trimmingCharacters(in: .whitespacesAndNewlines).count <= 2 {
             paras.removeLast()
         }
-        return ScrollViewReader { proxy in
-            ScrollView {
-                // LazyVStack, not VStack: a long transcript in a plain VStack
-                // lays out every paragraph eagerly and the content layer grows
-                // past CoreAnimation's max backing-store size ("Failed to create
-                // image slot"), stalling the main thread (the swap-time hang).
-                // Lazy only realises the visible paragraphs.
-                LazyVStack(alignment: .leading, spacing: 8) {
-                    ForEach(paras) { para in
-                        paragraphView(para)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .id(para.id)
-                    }
-                }
-                .padding()
-            }
-            .onChange(of: paras.count) { _, _ in
-                if let last = paras.last {
-                    withAnimation { proxy.scrollTo(last.id, anchor: .bottom) }
-                }
-            }
-        }
+        // A UITextView (not SwiftUI Text) so the transcript can be selected and
+        // copied, and so a tap can resolve to the word under it for dictionary
+        // lookup. Lookup is enabled only when the game bundles a dictionary and
+        // we're at a command prompt; UITextView also handles long transcripts
+        // efficiently (TextKit), so it sidesteps the old backing-store overflow.
+        return TranscriptTextView(
+            paragraphs: paras,
+            lookupEnabled: hasDictionary && bridge.pendingInput?.type == "line",
+            onLookup: { bridge.lookUp($0) })
     }
 
     // MARK: Input
@@ -202,36 +196,8 @@ struct GameView: View {
         spans.reduce(Text("")) { $0 + styled($1) }
     }
 
-    private func paragraphText(_ para: RenderedParagraph) -> Text {
-        para.spans.reduce(Text("")) { $0 + styled($1) }
-    }
-
-    /// A buffer paragraph. If it contains an image span, lay the spans out
-    /// vertically (images become Image views); otherwise take the fast path of
-    /// a single concatenated Text.
-    @ViewBuilder
-    private func paragraphView(_ para: RenderedParagraph) -> some View {
-        if para.spans.contains(where: { $0.image != nil }) {
-            VStack(alignment: .leading, spacing: 6) {
-                ForEach(para.spans) { span in
-                    if let num = span.image {
-                        if let img = BlorbImageCache.shared.image(num) {
-                            Image(uiImage: img)
-                                .resizable()
-                                .scaledToFit()
-                                .frame(maxWidth: .infinity, alignment: .center)
-                        }
-                    } else if !span.text.isEmpty {
-                        styled(span)
-                    }
-                }
-            }
-        } else {
-            paragraphText(para)
-        }
-    }
-
-    /// Map a Glk style name to SwiftUI text styling.
+    /// Map a Glk style name to SwiftUI text styling (used by the grid window;
+    /// the buffer transcript renders via TranscriptTextView).
     private func styled(_ span: RenderedSpan) -> Text {
         var t = Text(span.text)
         switch span.style {
@@ -247,5 +213,121 @@ struct GameView: View {
             t = t.foregroundColor(.accentColor).underline()
         }
         return t
+    }
+}
+
+// MARK: - Transcript (UITextView: selection/copy + tap-to-lookup)
+
+/// The scrolling game transcript, in a UITextView so it can be selected and
+/// copied, and (for dictionary games) so a tap resolves to the word under it.
+/// UITextView/TextKit also paginates long transcripts efficiently.
+struct TranscriptTextView: UIViewRepresentable {
+    let paragraphs: [RenderedParagraph]
+    let lookupEnabled: Bool
+    let onLookup: (String) -> Void
+
+    func makeUIView(context: Context) -> UITextView {
+        let tv = UITextView()
+        tv.isEditable = false
+        tv.isSelectable = true
+        tv.backgroundColor = .clear
+        tv.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        tv.alwaysBounceVertical = true
+        let tap = UITapGestureRecognizer(target: context.coordinator,
+                                         action: #selector(Coordinator.handleTap(_:)))
+        tap.cancelsTouchesInView = false   // don't swallow selection or scrolling
+        tv.addGestureRecognizer(tap)
+        return tv
+    }
+
+    func updateUIView(_ tv: UITextView, context: Context) {
+        context.coordinator.lookupEnabled = lookupEnabled
+        context.coordinator.onLookup = onLookup
+        // Rebuild only when the text actually changed, so an in-progress
+        // selection isn't dropped by an unrelated SwiftUI update.
+        let lastLen = paragraphs.last?.spans.reduce(0) { $0 + $1.text.count } ?? 0
+        let sig = "\(paragraphs.count)|\(lastLen)"
+        guard sig != context.coordinator.lastSig else { return }
+        context.coordinator.lastSig = sig
+        tv.attributedText = Self.attributed(paragraphs,
+                                            baseFont: UIFont.preferredFont(forTextStyle: .body))
+        DispatchQueue.main.async {
+            guard tv.attributedText.length > 0 else { return }
+            tv.scrollRangeToVisible(NSRange(location: tv.attributedText.length - 1, length: 1))
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator: NSObject {
+        var lookupEnabled = false
+        var onLookup: (String) -> Void = { _ in }
+        var lastSig = ""
+
+        @objc func handleTap(_ g: UITapGestureRecognizer) {
+            guard lookupEnabled, let tv = g.view as? UITextView else { return }
+            if let sel = tv.selectedTextRange, !sel.isEmpty { return }   // selecting -> leave it
+            let pt = g.location(in: tv)
+            guard let pos = tv.closestPosition(to: pt) else { return }
+            for dir in [UITextDirection.storage(.forward), UITextDirection.storage(.backward)] {
+                if let range = tv.tokenizer.rangeEnclosingPosition(pos, with: .word, inDirection: dir),
+                   let word = tv.text(in: range), !word.isEmpty {
+                    onLookup(word)
+                    return
+                }
+            }
+        }
+    }
+
+    private static func attributed(_ paragraphs: [RenderedParagraph],
+                                   baseFont: UIFont) -> NSAttributedString {
+        let out = NSMutableAttributedString()
+        let maxImageW = UIScreen.main.bounds.width - 24
+        for (i, para) in paragraphs.enumerated() {
+            if i > 0 { out.append(NSAttributedString(string: "\n\n")) }
+            for span in para.spans {
+                if let num = span.image, let img = BlorbImageCache.shared.image(num) {
+                    let att = NSTextAttachment()
+                    att.image = img
+                    let scale = min(1, maxImageW / max(1, img.size.width))
+                    att.bounds = CGRect(x: 0, y: 0,
+                                        width: img.size.width * scale,
+                                        height: img.size.height * scale)
+                    out.append(NSAttributedString(attachment: att))
+                } else if !span.text.isEmpty {
+                    out.append(span.attributedString(baseFont: baseFont))
+                }
+            }
+        }
+        return out
+    }
+}
+
+private extension RenderedSpan {
+    /// NSAttributedString form of GameView.styled (Glk style -> text attributes).
+    func attributedString(baseFont: UIFont) -> NSAttributedString {
+        var font = baseFont
+        var color = UIColor.label
+        var underline = false
+        switch style {
+        case "header", "subheader": font = baseFont.withTraits(.traitBold)
+        case "emphasized", "note":  font = baseFont.withTraits(.traitItalic)
+        case "alert":               color = .systemRed
+        case "input":               color = .tintColor
+        case "preformatted", "user1", "user2":
+            font = .monospacedSystemFont(ofSize: baseFont.pointSize, weight: .regular)
+        default: break
+        }
+        if hyperlink != nil { color = .tintColor; underline = true }
+        var attrs: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: color]
+        if underline { attrs[.underlineStyle] = NSUnderlineStyle.single.rawValue }
+        return NSAttributedString(string: text, attributes: attrs)
+    }
+}
+
+private extension UIFont {
+    func withTraits(_ traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
+        guard let d = fontDescriptor.withSymbolicTraits(traits) else { return self }
+        return UIFont(descriptor: d, size: pointSize)
     }
 }

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -233,10 +233,7 @@ struct TranscriptTextView: UIViewRepresentable {
         tv.backgroundColor = .clear
         tv.textContainerInset = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
         tv.alwaysBounceVertical = true
-        let tap = UITapGestureRecognizer(target: context.coordinator,
-                                         action: #selector(Coordinator.handleTap(_:)))
-        tap.cancelsTouchesInView = false   // don't swallow selection or scrolling
-        tv.addGestureRecognizer(tap)
+        tv.delegate = context.coordinator   // adds the "Define" edit-menu item
         return tv
     }
 
@@ -259,23 +256,22 @@ struct TranscriptTextView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    final class Coordinator: NSObject {
+    final class Coordinator: NSObject, UITextViewDelegate {
         var lookupEnabled = false
         var onLookup: (String) -> Void = { _ in }
         var lastSig = ""
 
-        @objc func handleTap(_ g: UITapGestureRecognizer) {
-            guard lookupEnabled, let tv = g.view as? UITextView else { return }
-            if let sel = tv.selectedTextRange, !sel.isEmpty { return }   // selecting -> leave it
-            let pt = g.location(in: tv)
-            guard let pos = tv.closestPosition(to: pt) else { return }
-            for dir in [UITextDirection.storage(.forward), UITextDirection.storage(.backward)] {
-                if let range = tv.tokenizer.rangeEnclosingPosition(pos, with: .word, inDirection: dir),
-                   let word = tv.text(in: range), !word.isEmpty {
-                    onLookup(word)
-                    return
-                }
-            }
+        // Long-press selects a word and opens the edit menu; for dictionary
+        // games, add a "Define" item next to Copy that looks up the selection.
+        func textView(_ textView: UITextView, editMenuForTextIn range: NSRange,
+                      suggestedActions: [UIMenuElement]) -> UIMenu? {
+            guard lookupEnabled, range.length > 0 else { return nil }
+            let sel = (textView.text as NSString).substring(with: range)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            // Only a single word is a valid lookup (matches the web).
+            guard !sel.isEmpty, !sel.contains(" ") else { return nil }
+            let define = UIAction(title: "Define") { [weak self] _ in self?.onLookup(sel) }
+            return UIMenu(children: [define] + suggestedActions)
         }
     }
 

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -136,6 +136,15 @@ final class GlkBridge: ObservableObject {
         pendingInput = nil
     }
 
+    /// Look up `word` in the game's bundled dictionary by submitting the game's
+    /// `lookup <word>` verb (same path the web uses on a word selection). The
+    /// definition is printed into the transcript. Only fires at a line prompt.
+    func lookUp(_ word: String) {
+        let clean = word.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        guard !clean.isEmpty else { return }
+        submitLine("lookup \(clean)")
+    }
+
     /// Submit a single character (for char input).
     func submitChar(_ value: String) {
         guard let req = pendingInput, req.type == "char" else { return }

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -80,9 +80,15 @@ struct GameShelfView: View {
                     // distinct Game, so its @StateObject bridge / @State started
                     // are fresh per game. The older `NavigationLink { GameView }`
                     // form let SwiftUI share one destination's state across games.
-                    List(games) { game in
-                        NavigationLink(game.title, value: game)
-                            .listRowBackground(Color.clear)
+                    List {
+                        ForEach(games) { game in
+                            NavigationLink(game.title, value: game)
+                                .listRowBackground(Color.clear)
+                        }
+                        .onDelete { offsets in
+                            offsets.map { games[$0] }.forEach(GameLibrary.delete)
+                            games.remove(atOffsets: offsets)
+                        }
                     }
                     .scrollContentBackground(.hidden)   // let the artwork show through
                     .navigationDestination(for: Game.self) { game in
@@ -129,6 +135,9 @@ struct GameShelfView: View {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button { importing = true } label: { Image(systemName: "plus") }
                         .accessibilityLabel("Import game")
+                }
+                if !games.isEmpty {
+                    ToolbarItem(placement: .topBarTrailing) { EditButton() }
                 }
             }
             .sheet(isPresented: $showingSettings) { SettingsView() }
@@ -232,15 +241,37 @@ enum GameLibrary {
         return ext == "j2" ? dest : nil
     }
 
+    /// Delete a game: its `.j2` and matching `.blorb`. Shared dictionaries in
+    /// data/ are left alone -- other games of the same language may use them.
+    /// (To *update* a game, just re-import the new .jaclgame: the importer
+    /// overwrites the same-named .j2/.blorb and adds any new data/ files.)
+    static func delete(_ game: Game) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: game.url)
+        try? fm.removeItem(at: game.url.deletingPathExtension().appendingPathExtension("blorb"))
+    }
+
     /// Unpack a `.jaclgame` (zip of `.j2` [+ `.blorb`]) into Documents/.
     private static func unpack(_ url: URL) throws -> URL? {
         let entries = try MiniZip.entries(of: Data(contentsOf: url))
         var game: URL?
         for entry in entries {
-            let name = (entry.name as NSString).lastPathComponent
-            let ext = (name as NSString).pathExtension.lowercased()
-            guard ext == "j2" || ext == "blorb" else { continue }   // ignore stray files
-            let dest = documents.appendingPathComponent(name)
+            let base = (entry.name as NSString).lastPathComponent
+            let ext = (base as NSString).pathExtension.lowercased()
+            let dest: URL
+            switch ext {
+            case "j2", "blorb":
+                dest = documents.appendingPathComponent(base)   // flat at the sandbox root
+            case "csv":
+                // A dictionary for the click-to-define feature. The interpreter
+                // opens it as `data/<lang>_words.csv` under the game dir, so it
+                // must land in Documents/data/, not the root.
+                let dataDir = documents.appendingPathComponent("data", isDirectory: true)
+                try? FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
+                dest = dataDir.appendingPathComponent(base)
+            default:
+                continue   // ignore stray files
+            }
             try? FileManager.default.removeItem(at: dest)
             try entry.data.write(to: dest)
             if ext == "j2" { game = dest }

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -64,9 +64,12 @@ extern int			jpp_error;
 struct	string_type	*resolved_string;
 #endif
 
-char            include_directory[81] = "\0";
-char            temp_directory[81] = "\0";
-char            data_directory[81] = "\0";
+/* 512, not 81: these are game_path (256) + a subdir suffix. On a sandboxed
+ * iOS install game_path alone is ~135 chars, so 81 truncated data_directory
+ * mid-path and CSV/data lookups (iterate "x.csv") failed to open. */
+char            include_directory[512] = "\0";
+char            temp_directory[512] = "\0";
+char            data_directory[512] = "\0";
 char            special_prompt[81] = "\n: \0";
 char            file_prompt[5] = ": \0";
 char            bookmark[81] = "\0";

--- a/src/utils.c
+++ b/src/utils.c
@@ -182,15 +182,15 @@ create_paths(char *full_path)
 	 * any time game_path was longer than ~72 chars -- easy to hit
 	 * with a deeper install layout. snprintf truncates instead. */
 	if (include_directory[0] == 0) {
-		snprintf(include_directory, 81, "%s%s", game_path, INCLUDE_DIR);
+		snprintf(include_directory, 512, "%s%s", game_path, INCLUDE_DIR);
 	}
 
 	if (temp_directory[0] == 0) {
-		snprintf(temp_directory, 81, "%s%s", game_path, TEMP_DIR);
+		snprintf(temp_directory, 512, "%s%s", game_path, TEMP_DIR);
 	}
 
 	if (data_directory[0] == 0) {
-		snprintf(data_directory, 81, "%s%s", game_path, DATA_DIR);
+		snprintf(data_directory, 512, "%s%s", game_path, DATA_DIR);
 	}
 }
 


### PR DESCRIPTION
Adds the web's click-a-word dictionary feature to the iPad app, plus the surrounding fixes and game-management it needed.

## Dictionary lookup
- **Path fix (core):** `include/temp/data_directory` were 81-byte buffers but hold `game_path` (256) + a subdir. On a sandboxed iOS install `game_path` is ~135 chars, so `data_directory` was truncated mid-path and `iterate "x.csv"` failed with *"No such file"*. Enlarged to 512 (no effect on desktop/web — short paths).
- **Bundling:** `build-jaclgames.sh` now packages `data/<lang>_words.csv` for any game that includes `<lang>_verbs.library` (french/german/spanish/indonesian); the zip stops junking paths so `data/` is preserved. `GameLibrary.unpack` extracts CSVs into `Documents/data/`.
- **UX:** the transcript is now a `UITextView`, so you can **select + copy** text, and **long-press a word → "Define"** (next to Copy) submits the game's `lookup <word>` verb — the definition prints into the transcript, exactly like the web's select-a-word flow. Enabled only for games that bundle a dictionary.

## Game management
- Swipe-to-delete + an Edit button on the shelf. Updating a game = re-import its `.jaclgame` (the importer overwrites the same-named `.j2`/`.blorb` and adds new `data/` files).

## Verified on the iPad Pro 11" simulator
- Package bundles `data/indonesian_words.csv`; import restores it to `Documents/data/`; `arti rumah` → *"The word rumah means house."*
- UITextView transcript renders styles, the title image, and scroll identically to before.

(Touch interactions — long-press Define, copy — confirmed by build + on-device testing; they can't be driven headlessly.)

## Deploy
Server side is just `git pull && ./configure && make apache` — `install` copies the CSVs and `apache` re-runs `build-jaclgames.sh`. The iOS app builds from this branch in Xcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)