### PR TITLE
iPad dictionary polish: native Define popover, generic bundling, phrase lookup

### DIFF
--- a/etc/build-jaclgames.sh
+++ b/etc/build-jaclgames.sh
@@ -91,10 +91,14 @@ for game in "$projects"/*.jacl; do
     # Bundle the matching language dictionary for click-to-define. A game that
     # includes <lang>_verbs.library runs `iterate "<lang>_words.csv"`, which the
     # interpreter opens under the game's data/ dir -- so package the CSV at
-    # data/<lang>_words.csv. (french / german / spanish / indonesian.)
-    for lang in french german spanish indonesian; do
-        if grep -qE "#include[[:space:]]+\"?${lang}_verbs\.library" "$game" \
-           && [ -f "$projects/data/${lang}_words.csv" ]; then
+    # data/<lang>_words.csv. The language list is derived from the game's own
+    # #include lines (not hardcoded), so a new language just works once its
+    # <lang>_verbs.library and <lang>_words.csv exist. Plain `verbs.library`
+    # (English, no prefix) has no _verbs prefix to match, so it's skipped.
+    langs=$(grep -oE '#include[[:space:]]+"?[a-z]+_verbs\.library' "$game" \
+            | grep -oE '[a-z]+_verbs\.library' | sed 's/_verbs\.library$//' | sort -u)
+    for lang in $langs; do
+        if [ -f "$projects/data/${lang}_words.csv" ]; then
             mkdir -p "$tmp/data"
             cp "$projects/data/${lang}_words.csv" "$tmp/data/${lang}_words.csv"
             files="$files data/${lang}_words.csv"

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -32,15 +32,52 @@ final class BlorbImageCache {
     func clear() { store.removeAll() }
 }
 
+/// The bundled language glossary for a game: every `data/*_words.csv` merged
+/// into one lookup, loaded once for native long-press "Define". Keys are
+/// lowercased words/phrases; values are the English gloss. Matches the
+/// interpreter's CSV shape -- field[0] is the word (never quoted), field[1] the
+/// definition, which may be quoted because it can hold commas (e.g.
+/// `acara,"event, program"`).
+struct GameDictionary {
+    private let entries: [String: String]
+    var isEmpty: Bool { entries.isEmpty }
+
+    init(dataDir: String) {
+        var map: [String: String] = [:]
+        let files = ((try? FileManager.default.contentsOfDirectory(atPath: dataDir)) ?? [])
+            .filter { $0.hasSuffix("_words.csv") }
+        for file in files {
+            guard let text = try? String(contentsOfFile: "\(dataDir)/\(file)", encoding: .utf8)
+            else { continue }
+            var isHeader = true
+            for line in text.split(whereSeparator: \.isNewline) {
+                if isHeader { isHeader = false; continue }     // skip header row
+                guard let comma = line.firstIndex(of: ",") else { continue }
+                let key = line[..<comma].trimmingCharacters(in: .whitespaces).lowercased()
+                guard !key.isEmpty else { continue }
+                var def = line[line.index(after: comma)...].trimmingCharacters(in: .whitespaces)
+                if def.count >= 2, def.hasPrefix("\""), def.hasSuffix("\"") {
+                    def = String(def.dropFirst().dropLast())   // unquote a comma-bearing gloss
+                }
+                map[key] = def
+            }
+        }
+        entries = map
+    }
+
+    /// The gloss for `word` (case-insensitive), or nil if it isn't in any CSV.
+    func define(_ word: String) -> String? { entries[word.lowercased()] }
+}
+
 struct GameView: View {
     let gamePath: String
 
     @StateObject private var bridge = GlkBridge()
     @State private var inputText = ""
     @State private var started = false
-    /// True if a `*_words.csv` dictionary is bundled next to this game, which
-    /// enables tap-a-word lookup. Computed once on appear.
-    @State private var hasDictionary = false
+    /// The bundled language glossary (merged `data/*_words.csv`), if this game
+    /// ships one -- enables native long-press "Define". Loaded once on appear.
+    @State private var dictionary: GameDictionary?
     @FocusState private var inputFocused: Bool
 
     // DEBUG-only scripted input (via `-autocommands "no;look;…"`), used to
@@ -66,10 +103,11 @@ struct GameView: View {
             .onAppear {
                 guard !started else { return }
                 started = true
-                // A dictionary lives at <gameDir>/data/<lang>_words.csv.
+                // A dictionary lives at <gameDir>/data/<lang>_words.csv; load it
+                // once for native long-press "Define" (no command, no turn).
                 let dataDir = (gamePath as NSString).deletingLastPathComponent + "/data"
-                hasDictionary = ((try? FileManager.default.contentsOfDirectory(atPath: dataDir)) ?? [])
-                    .contains { $0.hasSuffix("_words.csv") }
+                let dict = GameDictionary(dataDir: dataDir)
+                dictionary = dict.isEmpty ? nil : dict
                 bridge.start(gamePath: gamePath, size: geo.size)
             }
             .onDisappear {
@@ -140,14 +178,12 @@ struct GameView: View {
             paras.removeLast()
         }
         // A UITextView (not SwiftUI Text) so the transcript can be selected and
-        // copied, and so a tap can resolve to the word under it for dictionary
-        // lookup. Lookup is enabled only when the game bundles a dictionary and
-        // we're at a command prompt; UITextView also handles long transcripts
-        // efficiently (TextKit), so it sidesteps the old backing-store overflow.
-        return TranscriptTextView(
-            paragraphs: paras,
-            lookupEnabled: hasDictionary && bridge.pendingInput?.type == "line",
-            onLookup: { bridge.lookUp($0) })
+        // copied, and so long-pressing a word can define it from the bundled
+        // glossary (a native popover -- no command echo, no turn, and it works
+        // any time, not just at a prompt). UITextView/TextKit also paginates
+        // long transcripts efficiently, sidestepping the old backing-store
+        // overflow.
+        return TranscriptTextView(paragraphs: paras, dictionary: dictionary)
     }
 
     // MARK: Input
@@ -223,8 +259,7 @@ struct GameView: View {
 /// UITextView/TextKit also paginates long transcripts efficiently.
 struct TranscriptTextView: UIViewRepresentable {
     let paragraphs: [RenderedParagraph]
-    let lookupEnabled: Bool
-    let onLookup: (String) -> Void
+    let dictionary: GameDictionary?
 
     func makeUIView(context: Context) -> UITextView {
         let tv = UITextView()
@@ -238,8 +273,7 @@ struct TranscriptTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ tv: UITextView, context: Context) {
-        context.coordinator.lookupEnabled = lookupEnabled
-        context.coordinator.onLookup = onLookup
+        context.coordinator.dictionary = dictionary
         // Rebuild only when the text actually changed, so an in-progress
         // selection isn't dropped by an unrelated SwiftUI update.
         let lastLen = paragraphs.last?.spans.reduce(0) { $0 + $1.text.count } ?? 0
@@ -256,22 +290,62 @@ struct TranscriptTextView: UIViewRepresentable {
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
-    final class Coordinator: NSObject, UITextViewDelegate {
-        var lookupEnabled = false
-        var onLookup: (String) -> Void = { _ in }
+    final class Coordinator: NSObject, UITextViewDelegate, UIPopoverPresentationControllerDelegate {
+        var dictionary: GameDictionary?
         var lastSig = ""
 
-        // Long-press selects a word and opens the edit menu; for dictionary
-        // games, add a "Define" item next to Copy that looks up the selection.
+        // Long-press selects text and opens the edit menu; when the game ships a
+        // glossary, add a "Define" item next to Copy. Tapping it shows the gloss
+        // in a popover anchored to the selection -- no command, no turn, and it
+        // works any time (even mid-game), unlike the old `lookup` verb path.
         func textView(_ textView: UITextView, editMenuForTextIn range: NSRange,
                       suggestedActions: [UIMenuElement]) -> UIMenu? {
-            guard lookupEnabled, range.length > 0 else { return nil }
-            let sel = (textView.text as NSString).substring(with: range)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            // Only a single word is a valid lookup (matches the web).
-            guard !sel.isEmpty, !sel.contains(" ") else { return nil }
-            let define = UIAction(title: "Define") { [weak self] _ in self?.onLookup(sel) }
+            guard dictionary != nil, range.length > 0 else { return nil }
+            // Fold the selection into a lookup key: trim and collapse internal
+            // whitespace/line-wraps to single spaces, so a wrapped phrase still
+            // matches a CSV key like "abu abu". Cap the length so a giant
+            // multi-paragraph selection doesn't try to be a single word.
+            let key = (textView.text as NSString).substring(with: range)
+                .components(separatedBy: .whitespacesAndNewlines)
+                .filter { !$0.isEmpty }.joined(separator: " ")
+            guard !key.isEmpty, key.count <= 40 else { return nil }
+            let define = UIAction(title: "Define") { [weak self, weak textView] _ in
+                self?.define(key, in: textView)
+            }
             return UIMenu(children: [define] + suggestedActions)
+        }
+
+        private func define(_ word: String, in textView: UITextView?) {
+            guard let textView else { return }
+            let body = dictionary?.define(word).map { "\(word) — \($0)" }
+                ?? "“\(word)” isn’t in the dictionary."
+            let popover = DefinitionViewController(text: body)
+            popover.modalPresentationStyle = .popover
+            if let pop = popover.popoverPresentationController {
+                pop.sourceView = textView
+                pop.sourceRect = textView.selectedTextRange
+                    .map { textView.firstRect(for: $0) }
+                    ?? CGRect(x: textView.bounds.midX, y: textView.bounds.midY, width: 1, height: 1)
+                pop.permittedArrowDirections = [.up, .down]
+                pop.delegate = self
+            }
+            Coordinator.presenter(for: textView)?.present(popover, animated: true)
+        }
+
+        // Keep it a popover (arrow, anchored) even on compact widths, rather
+        // than letting iOS promote it to a full-screen sheet.
+        func adaptivePresentationStyle(for controller: UIPresentationController)
+            -> UIModalPresentationStyle { .none }
+
+        /// Nearest presenting view controller, walked up the responder chain
+        /// (the UITextView lives inside SwiftUI's UIHostingController).
+        private static func presenter(for view: UIView) -> UIViewController? {
+            var responder: UIResponder? = view
+            while let r = responder {
+                if let vc = r as? UIViewController { return vc }
+                responder = r.next
+            }
+            return view.window?.rootViewController
         }
     }
 
@@ -325,5 +399,43 @@ private extension UIFont {
     func withTraits(_ traits: UIFontDescriptor.SymbolicTraits) -> UIFont {
         guard let d = fontDescriptor.withSymbolicTraits(traits) else { return self }
         return UIFont(descriptor: d, size: pointSize)
+    }
+}
+
+// MARK: - Definition popover
+
+/// A small popover that shows a word's gloss for long-press "Define". Sizes
+/// itself to the text so the popover hugs the definition.
+private final class DefinitionViewController: UIViewController {
+    private let text: String
+    init(text: String) { self.text = text; super.init(nibName: nil, bundle: nil) }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .secondarySystemBackground
+        let pad: CGFloat = 14
+        let maxTextWidth: CGFloat = 252
+        let font = UIFont.preferredFont(forTextStyle: .body)
+
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.text = text
+        label.font = font
+        label.preferredMaxLayoutWidth = maxTextWidth
+        label.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(label)
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: view.topAnchor, constant: pad),
+            label.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -pad),
+            label.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: pad),
+            label.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -pad),
+        ])
+        let textSize = (text as NSString).boundingRect(
+            with: CGSize(width: maxTextWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: font], context: nil)
+        preferredContentSize = CGSize(width: ceil(textSize.width) + pad * 2,
+                                      height: ceil(textSize.height) + pad * 2)
     }
 }

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -136,15 +136,6 @@ final class GlkBridge: ObservableObject {
         pendingInput = nil
     }
 
-    /// Look up `word` in the game's bundled dictionary by submitting the game's
-    /// `lookup <word>` verb (same path the web uses on a word selection). The
-    /// definition is printed into the transcript. Only fires at a line prompt.
-    func lookUp(_ word: String) {
-        let clean = word.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        guard !clean.isEmpty else { return }
-        submitLine("lookup \(clean)")
-    }
-
     /// Submit a single character (for char input).
     func submitChar(_ value: String) {
         guard let req = pendingInput, req.type == "char" else { return }

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -241,20 +241,53 @@ enum GameLibrary {
         return ext == "j2" ? dest : nil
     }
 
-    /// Delete a game: its `.j2` and matching `.blorb`. Shared dictionaries in
-    /// data/ are left alone -- other games of the same language may use them.
+    /// Delete a game: its `.j2`, matching `.blorb`, and any bundled dictionary
+    /// no longer used by another installed game (see `pruneDictionaries`).
     /// (To *update* a game, just re-import the new .jaclgame: the importer
     /// overwrites the same-named .j2/.blorb and adds any new data/ files.)
     static func delete(_ game: Game) {
         let fm = FileManager.default
         try? fm.removeItem(at: game.url)
         try? fm.removeItem(at: game.url.deletingPathExtension().appendingPathExtension("blorb"))
+        pruneDictionaries(removing: game.url.deletingPathExtension().lastPathComponent)
+    }
+
+    /// Key for the dictionary manifest: game base name -> the `*_words.csv`
+    /// files that game's package bundled. Lets `delete` garbage-collect a CSV
+    /// once no installed game needs it, while a glossary shared by two games of
+    /// the same language survives until the last one is removed.
+    private static let manifestKey = "dictManifest"
+
+    private static func dictManifest() -> [String: [String]] {
+        UserDefaults.standard.dictionary(forKey: manifestKey) as? [String: [String]] ?? [:]
+    }
+
+    /// Drop `name` from the manifest, then delete any CSV it brought that no
+    /// remaining game references. Skips pruning entirely if any installed game
+    /// predates the manifest (imported by an older build): we can't tell which
+    /// CSV such a game needs, so we keep them all rather than risk pulling a
+    /// dictionary out from under it. Re-importing those games fills the manifest.
+    private static func pruneDictionaries(removing name: String) {
+        var manifest = dictManifest()
+        let removed = manifest.removeValue(forKey: name) ?? []
+        UserDefaults.standard.set(manifest, forKey: manifestKey)
+        guard !removed.isEmpty else { return }
+
+        let remaining = Set(games().map { $0.url.deletingPathExtension().lastPathComponent })
+        guard remaining.isSubset(of: Set(manifest.keys)) else { return }
+
+        let stillNeeded = Set(manifest.values.flatMap { $0 })
+        let dataDir = documents.appendingPathComponent("data", isDirectory: true)
+        for csv in removed where !stillNeeded.contains(csv) {
+            try? FileManager.default.removeItem(at: dataDir.appendingPathComponent(csv))
+        }
     }
 
     /// Unpack a `.jaclgame` (zip of `.j2` [+ `.blorb`]) into Documents/.
     private static func unpack(_ url: URL) throws -> URL? {
         let entries = try MiniZip.entries(of: Data(contentsOf: url))
         var game: URL?
+        var bundledCSVs: [String] = []
         for entry in entries {
             let base = (entry.name as NSString).lastPathComponent
             let ext = (base as NSString).pathExtension.lowercased()
@@ -269,12 +302,20 @@ enum GameLibrary {
                 let dataDir = documents.appendingPathComponent("data", isDirectory: true)
                 try? FileManager.default.createDirectory(at: dataDir, withIntermediateDirectories: true)
                 dest = dataDir.appendingPathComponent(base)
+                bundledCSVs.append(base)
             default:
                 continue   // ignore stray files
             }
             try? FileManager.default.removeItem(at: dest)
             try entry.data.write(to: dest)
             if ext == "j2" { game = dest }
+        }
+        // Record which dictionaries this game brought, so deleting it can later
+        // garbage-collect them (but only once no other game still needs them).
+        if let game {
+            var manifest = dictManifest()
+            manifest[game.deletingPathExtension().lastPathComponent] = bundledCSVs
+            UserDefaults.standard.set(manifest, forKey: manifestKey)
         }
         return game
     }

--- a/projects/include/french_verbs.library
+++ b/projects/include/french_verbs.library
@@ -777,7 +777,7 @@ iterate "french_words.csv" skip_header
    endif
 enditerate
 if mot_trouve = false
-   write "Le mot ~" $string "~ n'est pas trouvé.^"
+   write "The word ~" $string "~ is not in the dictionary.^"
 endif
 set time = false
 }

--- a/projects/include/german_verbs.library
+++ b/projects/include/german_verbs.library
@@ -741,7 +741,7 @@ iterate "german_words.csv" skip_header
    endif
 enditerate
 if wort_gefunden = false
-   write "Das Wort ~" $string "~ steht nicht im Wörterbuch.^"
+   write "The word ~" $string "~ is not in the dictionary.^"
 endif
 set time = false
 }

--- a/projects/include/indonesian_verbs.library
+++ b/projects/include/indonesian_verbs.library
@@ -693,7 +693,7 @@ iterate "indonesian_words.csv" skip_header
    endif
 enditerate
 if kata_ditemukan = false
-   write "Kata ~" $string "~ tidak ditemukan.^"
+   write "The word ~" $string "~ is not in the dictionary.^"
 endif
 set time = false
 }

--- a/projects/include/spanish_verbs.library
+++ b/projects/include/spanish_verbs.library
@@ -698,7 +698,7 @@ iterate "spanish_words.csv" skip_header
    endif
 enditerate
 if palabra_encontrada = false
-   write "La palabra ~" $string "~ no se encontró.^"
+   write "The word ~" $string "~ is not in the dictionary.^"
 endif
 set time = false
 }


### PR DESCRIPTION
Follow-up to #73. Three refinements to the bundled-dictionary feature.

## 1 — Native definition popover (biggest change)
Long-press → **Define** previously submitted a `lookup <word>` verb, which echoed `>lookup rumah` into the transcript and only worked at a line prompt. It now loads the bundled `data/*_words.csv` into a `GameDictionary` once on appear and shows the gloss in a **popover anchored to the selection** — no command echo, no turn consumed, and it works any time (even mid-game).

- Quote-aware CSV parsing (field[1] may be quoted to hold internal commas, e.g. `acara,"event, program"`).
- Removed the old `bridge.lookUp` command path.

## 3 — Generic language detection
`build-jaclgames.sh` no longer hardcodes french/german/spanish/indonesian — it derives the language list from each game's own `<lang>_verbs.library` includes, so a new language Just Works once its verbs library and `words.csv` exist. Verified: `desa→indonesian`, `montana→spanish`, `paris→french`, `camion_frigo→french`, `*_tutorial→matching lang`.

## 4 — Consistency & robustness
- **(a)** All four libraries answer a miss with `"The word ~x~ is not in the dictionary."`, mirroring the English hit phrasing (was four different target-language messages).
- **(b)** Phrase lookups work — selecting `abu abu` (41 such keys in Indonesian) matches its CSV entry; the selection is whitespace-folded so a line-wrapped phrase still resolves.
- **(c)** Deleting a game garbage-collects its dictionaries via a manifest, but only once every installed game has a manifest entry — so a game imported by an older build never loses its glossary.

## Rollout
- iOS popover (#1) + GC (#4c): next Xcode build of the app.
- Library message change (#4a) requires rebuilding the affected games: `git pull && ./configure && make apache` on the server re-bundles packages with the generic detection (#3).

## Testing
- `xcodebuild` (iphonesimulator, Debug): **BUILD SUCCEEDED**.
- Language derivation verified against all seven non-English games in `projects/`.
- No dangling references to the removed `lookUp`/`hasDictionary`/`onLookup` symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)