### PR TITLE
iPad: serif (Hoefler Text) transcript font

### DIFF
--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -325,7 +325,7 @@ struct TranscriptTextView: UIViewRepresentable {
         guard sig != context.coordinator.lastSig else { return }
         context.coordinator.lastSig = sig
         tv.attributedText = Self.attributed(paragraphs,
-                                            baseFont: UIFont.systemFont(ofSize: fontSize),
+                                            baseFont: Self.transcriptFont(ofSize: fontSize),
                                             headerColor: headerColor)
         DispatchQueue.main.async {
             guard tv.attributedText.length > 0 else { return }
@@ -392,6 +392,14 @@ struct TranscriptTextView: UIViewRepresentable {
             }
             return view.window?.rootViewController
         }
+    }
+
+    /// Body font for the transcript: an old-style serif (Garamond-like, novel
+    /// feel) for comfortable reading, falling back to the system font if it
+    /// isn't available. Bold/italic/monospaced runs derive from this via
+    /// `attributedString(baseFont:)`; preformatted text stays monospaced.
+    static func transcriptFont(ofSize size: CGFloat) -> UIFont {
+        UIFont(name: "Hoefler Text", size: size) ?? UIFont.systemFont(ofSize: size)
     }
 
     private static func attributed(_ paragraphs: [RenderedParagraph],


### PR DESCRIPTION
Renders the game transcript in an old-style serif (**Hoefler Text**, Garamond-adjacent) for a printed-novel feel, instead of the system sans-serif.

- Falls back to the system font if Hoefler Text is unavailable.
- Bold/italic runs still derive from the base font; **preformatted** text and the fixed-width **status bar** stay monospaced.
- Pairs with the existing Text Size setting (the serif scales with it).

Verified on the simulator. One-line `transcriptFont(ofSize:)` helper makes swapping the face trivial if a different serif is preferred later, or if EB Garamond is bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)