### PR TITLE
iPad: Light/Dark/System appearance setting

### DIFF
--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -32,6 +32,32 @@ final class BlorbImageCache {
     func clear() { store.removeAll() }
 }
 
+/// In-app appearance choice for the reading screen, set in Settings. The shelf
+/// stays dark regardless (its cover-art watermark needs light text); this only
+/// drives the in-game transcript.
+enum AppearanceMode: String, CaseIterable, Identifiable {
+    case system, light, dark
+    var id: String { rawValue }
+    static let key = "appearanceMode"
+
+    var label: String {
+        switch self {
+        case .system: return "System"
+        case .light:  return "Light"
+        case .dark:   return "Dark"
+        }
+    }
+
+    /// The SwiftUI scheme to force, or nil to follow the device's OS setting.
+    var colorScheme: ColorScheme? {
+        switch self {
+        case .system: return nil
+        case .light:  return .light
+        case .dark:   return .dark
+        }
+    }
+}
+
 /// Reading preferences shared between the Settings screen and the game view.
 enum ReadingDefaults {
     /// Transcript text size in points. Default is roughly the system `.body`
@@ -95,6 +121,10 @@ struct GameView: View {
     @State private var headerColor: Color?
     /// Transcript text size, set in Settings and persisted app-wide.
     @AppStorage(ReadingDefaults.fontSizeKey) private var transcriptFontSize = ReadingDefaults.fontSize
+    /// In-game appearance (System / Light / Dark), set in Settings. Applied from
+    /// inside the reading screen so it drives the window even though the shelf's
+    /// navigationDestination otherwise detaches it from the stack's scheme.
+    @AppStorage(AppearanceMode.key) private var appearance = AppearanceMode.system
     @FocusState private var inputFocused: Bool
 
     // DEBUG-only scripted input (via `-autocommands "no;look;…"`), used to
@@ -164,6 +194,7 @@ struct GameView: View {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
+        .preferredColorScheme(appearance.colorScheme)
     }
 
     /// Parse `-autocommands "no;look;…"` from the launch args (DEBUG only).

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -92,10 +92,10 @@ struct GameShelfView: View {
                     }
                     .scrollContentBackground(.hidden)   // let the artwork show through
                     .navigationDestination(for: Game.self) { game in
-                        // Keep the in-game transcript on the light theme; only
-                        // the shelf goes dark for the watermark.
+                        // The reading screen inherits the window scheme, which
+                        // the Appearance setting drives (the stack modifier
+                        // below). System follows the device's Light/Dark.
                         GameView(gamePath: game.url.path)
-                            .preferredColorScheme(.light)
                     }
                 }
             }
@@ -181,8 +181,12 @@ struct GameShelfView: View {
                 games = result
                 loaded = true
             }
+            // Render the shelf content dark for its cover-art watermark (light
+            // text on a dark background), via an environment override so it
+            // holds regardless of the window's actual scheme. The reading
+            // screen's appearance is set from inside GameView itself.
+            .environment(\.colorScheme, .dark)
         }
-        .preferredColorScheme(.dark)   // light text on the dark shelf watermark
     }
 }
 

--- a/ios/JACL/SettingsView.swift
+++ b/ios/JACL/SettingsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @AppStorage(ReadingDefaults.fontSizeKey) private var fontSize = ReadingDefaults.fontSize
+    @AppStorage(AppearanceMode.key) private var appearance = AppearanceMode.system
 
     /// Opens the site's "Get it for iPad" downloads tab directly -- the #get
     /// fragment selects that tab. A plain Safari hand-off; no in-app network.
@@ -52,10 +53,16 @@ struct SettingsView: View {
                             .lineLimit(2)
                     }
                     .padding(.vertical, 4)
+
+                    Picker("Appearance", selection: $appearance) {
+                        ForEach(AppearanceMode.allCases) { Text($0.label).tag($0) }
+                    }
                 } header: {
                     Text("Reading")
                 } footer: {
-                    Text("Sets the size of the game transcript and command text.")
+                    Text("Text size and appearance apply to the game reading "
+                       + "screen. \u{201C}System\u{201D} follows your iPad's "
+                       + "Light/Dark setting; the shelf stays dark.")
                 }
 
                 Section {


### PR DESCRIPTION
Adds an **Appearance** picker (System / Light / Dark) to Settings, beside Text Size, persisted app-wide. The reading screen follows it; the **shelf stays dark** for its cover-art watermark regardless.

(Reopened as a fresh PR — the original #79 was auto-closed when the stacked base branch was deleted on merge. Rebased onto master so the diff is just the appearance commit.)

### Implementation note
- Scheme applied **from inside `GameView`** (not the `navigationDestination`, which detaches the pushed view from the stack's scheme) so it reaches the window.
- The shelf renders dark via an **environment `colorScheme` override** — not a window `preferredColorScheme` — so it doesn't claim the window's interface style, leaving **System** free to follow the OS.

### Verified on the simulator
| Setting | OS | Reading screen |
|--------|-----|----------------|
| System | Light | Light ✓ |
| System | Dark | Dark ✓ |
| Dark | Light | Dark ✓ |
| (shelf) | either | Dark ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)