### PR TITLE
Console: single reverse-video status bar by default (GlkTerm)

### DIFF
--- a/src/glkterm/main.c
+++ b/src/glkterm/main.c
@@ -19,8 +19,13 @@ int pref_printversion = FALSE;
 int pref_screenwidth = 0;
 int pref_screenheight = 0;
 int pref_messageline = TRUE;
-int pref_reverse_textgrids = FALSE;
-int pref_override_window_borders = FALSE;
+/* JACL defaults: render the status (grid) window as a single reverse-video
+ * bar with no separating rule -- the conventional IF status-line look, and a
+ * match for the iPad app's single status line. Upstream GlkTerm leaves grids
+ * in normal text with an auto-drawn window border; these three lines flip that.
+ * Still overridable from the command line with -revgrid no / -border yes. */
+int pref_reverse_textgrids = TRUE;
+int pref_override_window_borders = TRUE;
 int pref_window_borders = FALSE;
 int pref_precise_timing = FALSE;
 int pref_historylen = 20;


### PR DESCRIPTION
Makes the `jacl` console interpreter render the status (grid) window as a single **reverse-video bar with no separating rule** — the conventional IF status-line look, matching the iPad app's single status line.

Three GlkTerm preference defaults in `src/glkterm/main.c`:

| pref | was | now | effect |
|------|-----|-----|--------|
| `pref_reverse_textgrids` | FALSE | **TRUE** | reverse the grid window |
| `pref_override_window_borders` | FALSE | **TRUE** | honour the border pref instead of auto |
| `pref_window_borders` | FALSE | FALSE | …which means no border rule |

Still overridable per run: `-revgrid no`, `-border yes`.

### Before / after (default `jacl`, no flags)
```
BEFORE                                   AFTER
The Rusty Sword Tavern   Score:0 Moves:0   [reverse bar] The Rusty Sword Tavern … Score:0 Moves:0
---------------------------------------    (rule removed)
WARNING: This game contains…               WARNING: This game contains…
```

### Verification
Built a throwaway `jacl` and rendered dragon through a pty (pyte): with no flags the status row is now fully reverse-video (all cells reversed) and the `----` rule is gone.

### Notes
- `pref_reverse_textgrids` reverses *all* GlkTerm grid windows, not only the status line — for standard JACL games that's just the status bar, but a game drawing a full-screen grid would render it reversed too.
- Only affects `jacl` (GlkTerm). The web interpreters and CheapGlk are unaffected. Takes effect after a rebuild/reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)