### PR TITLE
iPad: scope Define to the game's own language

### DIFF
--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -68,23 +68,40 @@ enum ReadingDefaults {
     static let fontSizeKey = "transcriptFontSize"
 }
 
-/// The bundled language glossary for a game: every `data/*_words.csv` merged
-/// into one lookup, loaded once for native long-press "Define". Keys are
-/// lowercased words/phrases; values are the English gloss. Matches the
-/// interpreter's CSV shape -- field[0] is the word (never quoted), field[1] the
-/// definition, which may be quoted because it can hold commas (e.g.
-/// `acara,"event, program"`).
+/// The bundled glossary for a game: the single `<lang>_words.csv` matching the
+/// game's own declared language (`game_language`), loaded for native long-press
+/// "Define". Keys are lowercased words/phrases; values are the English gloss.
+/// Matches the interpreter's CSV shape -- field[0] is the word (never quoted),
+/// field[1] the definition, which may be quoted because it can hold commas
+/// (e.g. `acara,"event, program"`).
 struct GameDictionary {
     private let entries: [String: String]
     var isEmpty: Bool { entries.isEmpty }
 
-    init(dataDir: String) {
+    /// Map a game's `game_language` (BCP-47, e.g. "id-ID") to the CSV name. Only
+    /// languages that ship a dictionary are listed; English and anything else
+    /// return nil, which disables lookup for that game.
+    private static let csvForLanguage = [
+        "id": "indonesian_words.csv",
+        "fr": "french_words.csv",
+        "de": "german_words.csv",
+        "es": "spanish_words.csv",
+    ]
+
+    /// Load the glossary for `language` (the game's `game_language`) from
+    /// `dataDir`, or nil if that language has no matching CSV there.
+    static func forGame(dataDir: String, language: String?) -> GameDictionary? {
+        guard let sub = language?.split(separator: "-").first.map({ $0.lowercased() }),
+              let name = Self.csvForLanguage[sub] else { return nil }
+        let path = "\(dataDir)/\(name)"
+        guard FileManager.default.fileExists(atPath: path) else { return nil }
+        let dict = GameDictionary(csvPath: path)
+        return dict.isEmpty ? nil : dict
+    }
+
+    private init(csvPath: String) {
         var map: [String: String] = [:]
-        let files = ((try? FileManager.default.contentsOfDirectory(atPath: dataDir)) ?? [])
-            .filter { $0.hasSuffix("_words.csv") }
-        for file in files {
-            guard let text = try? String(contentsOfFile: "\(dataDir)/\(file)", encoding: .utf8)
-            else { continue }
+        if let text = try? String(contentsOfFile: csvPath, encoding: .utf8) {
             var isHeader = true
             for line in text.split(whereSeparator: \.isNewline) {
                 if isHeader { isHeader = false; continue }     // skip header row
@@ -101,7 +118,7 @@ struct GameDictionary {
         entries = map
     }
 
-    /// The gloss for `word` (case-insensitive), or nil if it isn't in any CSV.
+    /// The gloss for `word` (case-insensitive), or nil.
     func define(_ word: String) -> String? { entries[word.lowercased()] }
 }
 
@@ -150,11 +167,14 @@ struct GameView: View {
             .onAppear {
                 guard !started else { return }
                 started = true
-                // A dictionary lives at <gameDir>/data/<lang>_words.csv; load it
-                // once for native long-press "Define" (no command, no turn).
+                // Load the glossary for native long-press "Define" -- only the
+                // CSV matching THIS game's declared language (game_language), so
+                // an English game never offers another game's definitions. nil
+                // when the language ships no dictionary (English etc.).
                 let dataDir = (gamePath as NSString).deletingLastPathComponent + "/data"
-                let dict = GameDictionary(dataDir: dataDir)
-                dictionary = dict.isEmpty ? nil : dict
+                let url = URL(fileURLWithPath: gamePath)
+                dictionary = GameDictionary.forGame(
+                    dataDir: dataDir, language: GameLibrary.stringConstant("game_language", in: url))
                 // The per-game header colour the web interface uses for its
                 // title band; tint the iPad's top chrome to match.
                 headerColor = GameLibrary.stringConstant(

--- a/ios/JACL/JACLApp.swift
+++ b/ios/JACL/JACLApp.swift
@@ -377,7 +377,9 @@ enum GameLibrary {
     private static func quotedConstant(_ name: String, in bytes: [UInt8]) -> String? {
         guard let line = String(bytes: bytes, encoding: .utf8) else { return nil }
         let parts = line.split(whereSeparator: { $0 == " " || $0 == "\t" })
-        guard parts.count >= 2, parts[0] == "constant", parts[1] == name else { return nil }
+        // game_title / header_colour are `constant`; game_language is a `string`.
+        guard parts.count >= 2, parts[0] == "constant" || parts[0] == "string",
+              parts[1] == name else { return nil }
         guard let a = line.firstIndex(of: "\"") else { return nil }
         let after = line.index(after: a)
         guard let b = line[after...].firstIndex(of: "\"") else { return nil }


### PR DESCRIPTION
Mirrors the Android per-language fix. Long-press **Define** now loads **only** the `<lang>_words.csv` matching the game's declared `game_language` (e.g. `id-ID` → `indonesian_words.csv`), instead of merging every CSV in the shared `data/` dir.

- An English game no longer offers another installed game's (e.g. Indonesian) definitions.
- A language with no bundled dictionary (English, or any unmapped one) → **lookup disabled**, transcript stays plainly selectable.
- No authoring change: it reads the existing `game_language` the language libraries already set.

### Changes
- `GameDictionary.forGame(dataDir:language:)` maps the BCP-47 primary subtag → CSV and loads just that file (nil when unmapped/absent).
- `GameLibrary.stringConstant` now also reads `string` declarations (`game_language` is a `string`, not a `constant`).

### Testing
- `xcodebuild` (simulator): **BUILD SUCCEEDED**; smoke-tested (game renders, no crash).
- The long-press edit menu can't be driven headlessly on the simulator, but the logic is a direct port of the Android version verified on-device (desa/`id` defines `permainan→game`; dragon/`en` shows Copy, no Define).

🤖 Generated with [Claude Code](https://claude.com/claude-code)