### PR TITLE
android: per-language Define scoping + fuller Settings

### DIFF
--- a/android/app/src/main/java/au/com/dangarmarine/jacl/GameDictionary.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/GameDictionary.kt
@@ -3,11 +3,11 @@ package au.com.dangarmarine.jacl
 import java.io.File
 
 /**
- * The bundled language glossary for a game: every data/<lang>_words.csv merged
- * into one lookup, for long-press "Define". Port of the iOS GameDictionary.
- * Keys are lowercased words/phrases; values the English gloss. field[0] is the
- * word (never quoted); field[1] the definition, which may be quoted because it
- * can hold commas (e.g. `acara,"event, program"`).
+ * The bundled language glossary for a game -- the single <lang>_words.csv that
+ * matches the game's own declared language, for long-press "Define". Keys are
+ * lowercased words/phrases; values the English gloss. field[0] is the word
+ * (never quoted); field[1] the definition, which may be quoted because it can
+ * hold commas (e.g. `acara,"event, program"`).
  */
 class GameDictionary private constructor(private val entries: Map<String, String>) {
 
@@ -17,24 +17,46 @@ class GameDictionary private constructor(private val entries: Map<String, String
     fun define(word: String): String? = entries[word.lowercase()]
 
     companion object {
-        fun load(dataDir: File): GameDictionary {
+        /** Map a game's `game_language` (BCP-47, e.g. "id-ID") to the CSV name.
+         *  Only languages that ship a dictionary are listed; English and any
+         *  other language return null, which disables lookup for that game. */
+        private val CSV_FOR_LANG = mapOf(
+            "id" to "indonesian_words.csv",
+            "fr" to "french_words.csv",
+            "de" to "german_words.csv",
+            "es" to "spanish_words.csv",
+        )
+
+        fun csvName(gameLanguage: String?): String? {
+            val sub = gameLanguage?.substringBefore('-')?.lowercase() ?: return null
+            return CSV_FOR_LANG[sub]
+        }
+
+        /** Load the glossary for [game] from its declared language, or null if
+         *  the game's language has no matching CSV in [dataDir]. */
+        fun forGame(dataDir: File, gameLanguage: String?): GameDictionary? {
+            val name = csvName(gameLanguage) ?: return null
+            val csv = File(dataDir, name)
+            if (!csv.exists()) return null
+            val dict = load(csv)
+            return dict.takeUnless { it.isEmpty }
+        }
+
+        private fun load(csv: File): GameDictionary {
             val map = HashMap<String, String>()
-            val files = dataDir.listFiles { f -> f.name.endsWith("_words.csv") } ?: emptyArray()
-            for (f in files) {
-                val text = runCatching { f.readText() }.getOrNull() ?: continue
-                var header = true
-                for (raw in text.lineSequence()) {
-                    if (header) { header = false; continue }   // skip header row
-                    val comma = raw.indexOf(',')
-                    if (comma < 0) continue
-                    val key = raw.substring(0, comma).trim().lowercase()
-                    if (key.isEmpty()) continue
-                    var def = raw.substring(comma + 1).trim()
-                    if (def.length >= 2 && def.startsWith("\"") && def.endsWith("\"")) {
-                        def = def.substring(1, def.length - 1)   // unquote a comma-bearing gloss
-                    }
-                    map[key] = def
+            val text = runCatching { csv.readText() }.getOrNull() ?: return GameDictionary(map)
+            var header = true
+            for (raw in text.lineSequence()) {
+                if (header) { header = false; continue }   // skip header row
+                val comma = raw.indexOf(',')
+                if (comma < 0) continue
+                val key = raw.substring(0, comma).trim().lowercase()
+                if (key.isEmpty()) continue
+                var def = raw.substring(comma + 1).trim()
+                if (def.length >= 2 && def.startsWith("\"") && def.endsWith("\"")) {
+                    def = def.substring(1, def.length - 1)   // unquote a comma-bearing gloss
                 }
+                map[key] = def
             }
             return GameDictionary(map)
         }

--- a/android/app/src/main/java/au/com/dangarmarine/jacl/GameLibrary.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/GameLibrary.kt
@@ -123,7 +123,8 @@ object GameLibrary {
     private fun quotedConstant(bytes: ByteArray, name: String): String? {
         val line = String(bytes, Charsets.UTF_8)
         val parts = line.split(' ', '\t').filter { it.isNotEmpty() }
-        if (parts.size < 2 || parts[0] != "constant" || parts[1] != name) return null
+        // game_title / header_colour are `constant`; game_language is a `string`.
+        if (parts.size < 2 || (parts[0] != "constant" && parts[0] != "string") || parts[1] != name) return null
         val a = line.indexOf('"'); if (a < 0) return null
         val b = line.indexOf('"', a + 1); if (b < 0) return null
         return line.substring(a + 1, b)

--- a/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.*
 import androidx.compose.ui.text.font.FontFamily
@@ -234,12 +235,36 @@ fun SettingsScreen(prefs: AppPrefs, onClose: () -> Unit) {
             Text("Appearance applies to the reading screen; the shelf stays dark.",
                 style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
 
+            val uri = LocalUriHandler.current
+            Spacer(Modifier.height(8.dp))
+            HorizontalDivider()
+
+            SettingsLink("Get more games") { uri.openUri("https://jacl.dangarmarine.com.au/#get") }
+            Text("Browse the games at jacl.dangarmarine.com.au, then choose “Open in JACL” to install one.",
+                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
+            SettingsLink("Privacy Policy") { uri.openUri("https://jacl.dangarmarine.com.au/privacy.html") }
+            Text("JACL collects no personal data. Games and saved games stay on your device; the app makes "
+               + "no network connections and has no accounts or sign-in.",
+                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+
             Spacer(Modifier.height(8.dp))
             Text("About", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
-            Text("JACL v${GlkBridge.version} by Stuart Allen",
-                color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("Version  ${GlkBridge.version}", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            Text("JACL by Stuart Allen", color = MaterialTheme.colorScheme.onSurfaceVariant)
+            SettingsLink("jacl.dangarmarine.com.au") { uri.openUri("https://jacl.dangarmarine.com.au/") }
         }
     }
+}
+
+/** A tappable link row in Settings (opens a URL in the browser). */
+@Composable
+private fun SettingsLink(label: String, onClick: () -> Unit) {
+    Text(
+        label,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 8.dp),
+    )
 }
 
 // MARK: - Game
@@ -258,9 +283,12 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
     val headerColor = remember(game.file.path) {
         GameLibrary.stringConstant(game.file, "header_colour")?.let { parseHexColor(it) }
     }
-    // Bundled glossary (data/<lang>_words.csv) for long-press Define, if any.
+    // Glossary for long-press Define -- ONLY the CSV matching the game's own
+    // declared language (game_language); null (lookup disabled) for English or
+    // any language without a bundled dictionary.
     val dictionary = remember(game.file.path) {
-        GameDictionary.load(File(ctx.filesDir, "data")).takeUnless { it.isEmpty }
+        val lang = GameLibrary.stringConstant(game.file, "game_language")
+        GameDictionary.forGame(File(ctx.filesDir, "data"), lang)
     }
     var definition by remember { mutableStateOf<Pair<String, String>?>(null) }
     val onDefine: ((String) -> Unit)? = dictionary?.let { dict ->


### PR DESCRIPTION
The final Android commit that missed the #82 merge (which landed at an earlier tip). Re-applied onto master.

- **Per-language Define**: long-press uses only the CSV matching the game's `game_language` (e.g. `id-ID` → `indonesian_words.csv`); English / unmapped languages disable lookup and stay selectable. `stringConstant` reads `string` declarations too.
- **Settings**: Get more games, Privacy Policy, and About (version / author / website) links.

Verified on the Pixel Tablet emulator: desa/`id` defines `permainan→game`; dragon/`en` shows Copy (no Define); Settings shows the links. Matches the iPad fix (#83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)