### PR TITLE
Android: release signing config + build docs

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -9,3 +9,8 @@ local.properties
 captures/
 .externalNativeBuild/
 .kotlin/
+
+# Release signing -- never commit the keystore or its passwords
+keystore.properties
+*.jks
+*.keystore

--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,57 @@
+# JACL for Android
+
+A native Android tablet app that plays JACL games, running the **same C
+interpreter** as the iPad app: the JACL core (`../src`), RemGlk (`../ios/remglk`)
+and the embed glue (`../ios/ios_startup.c`, `../ios/jacl_bridge.c`) are
+cross-compiled to `libjacl.so` via the NDK/CMake, with a thin JNI shim
+(`app/src/main/cpp/android_jni.c`) and a Jetpack Compose UI.
+
+## Requirements
+
+- Android Studio (or the command-line SDK) with:
+  - **NDK 28.2.13676358** and **CMake 3.22.1** (declared in `app/build.gradle.kts`)
+  - a platform for `compileSdk 34`
+- A JDK 17+ (Android Studio's bundled JBR works).
+- `minSdk 29` (RemGlk's `timespec_get` for timers needs API 29).
+
+`local.properties` must point at your SDK (`sdk.dir=...`); it's gitignored.
+
+## Build & run (debug)
+
+```sh
+./gradlew :app:assembleDebug                 # build app-debug.apk
+./gradlew :app:installDebug                  # install on a connected device/emulator
+```
+
+The first build downloads the Android Gradle Plugin, Kotlin and Compose, then
+runs the native CMake build (`arm64-v8a` + `x86_64`).
+
+## Release signing
+
+Signing credentials are read from `keystore.properties` (gitignored), so no
+keystore or passwords are in the repo.
+
+1. Create a release keystore once (keep it safe — it identifies you as the
+   publisher and can't be regenerated):
+
+   ```sh
+   keytool -genkeypair -v -keystore jacl-release.jks -alias jacl \
+           -keyalg RSA -keysize 2048 -validity 10000
+   ```
+
+2. Copy the template and fill in the real values:
+
+   ```sh
+   cp keystore.properties.example keystore.properties
+   # edit keystore.properties (storeFile is relative to android/)
+   ```
+
+3. Build the signed artifacts:
+
+   ```sh
+   ./gradlew :app:assembleRelease    # signed APK  (app/build/outputs/apk/release/)
+   ./gradlew :app:bundleRelease      # signed AAB  (app/build/outputs/bundle/release/) for Google Play
+   ```
+
+Without `keystore.properties`, the release build still configures but is left
+unsigned (sign later with `apksigner` if needed).

--- a/android/RELEASE.md
+++ b/android/RELEASE.md
@@ -1,0 +1,78 @@
+# Releasing JACL for Android
+
+A checklist for publishing the app to Google Play (and/or distributing the APK
+directly). The build/signing mechanics are in [README.md](README.md); this is
+the "what do I actually need to do" list for shipping.
+
+## One-time setup
+
+1. **Google Play Developer account** — register at
+   <https://play.google.com/console> (one-time US$25 fee).
+2. **Create the app** in the Play Console (name: *JACL*, default language,
+   app/not game — your call, though it's a games platform).
+3. **Create the upload keystore** (once) and keep it + its passwords safe and
+   backed up off-machine — it is your publisher identity and **cannot be
+   regenerated**:
+   ```sh
+   cd android
+   keytool -genkeypair -v -keystore jacl-release.jks -alias jacl \
+           -keyalg RSA -keysize 2048 -validity 10000
+   cp keystore.properties.example keystore.properties   # fill in the passwords
+   ```
+4. **Enrol in Play App Signing** (recommended): you upload an AAB signed with
+   the *upload* key above; Google holds the real *app signing* key. If you ever
+   lose the upload key, Google can reset it.
+
+## Each release
+
+1. **Bump the version** in `app/build.gradle.kts` — `versionCode` must strictly
+   increase for every upload; set a human `versionName` (e.g. `1.0`).
+2. **Build the signed bundle**:
+   ```sh
+   ./gradlew :app:bundleRelease      # app/build/outputs/bundle/release/app-release.aab
+   ```
+3. **Smoke-test the release build** on a device/emulator (it's a different,
+   minified-config build than debug):
+   ```sh
+   ./gradlew :app:assembleRelease && adb install -r \
+     app/build/outputs/apk/release/app-release.apk
+   ```
+4. **Upload the `.aab`** to a Play Console track — start with **Internal
+   testing**, then promote to Closed → Open → Production.
+
+## Store-listing requirements (first submission)
+
+- App name, short description, full description.
+- Graphics: app icon (have it), **feature graphic** (1024×500), and
+  **screenshots** — include **7" and 10" tablet** screenshots (this is a tablet
+  app); phone screenshots too.
+- **Privacy policy URL** — <https://jacl.dangarmarine.com.au/privacy.html>
+  (already linked in the app's Settings).
+- **Data safety form** — declare **no data collected / no data shared**: the app
+  makes no network connections, has no accounts, and stores games + saves only
+  on-device.
+- **Content rating questionnaire** — note that the bundled *Down Dragon*
+  contains coarse language and adult themes; answer accordingly so the rating
+  is correct.
+- Target audience & ads — **no ads**; pick an appropriate age range.
+- Category / contact email / website.
+
+## Decisions worth making before launch
+
+- **ABIs**: the build ships `arm64-v8a` (real devices) + `x86_64` (emulators).
+  With an **AAB**, Play delivers per-device splits, so users only download their
+  own ABI — keeping `x86_64` costs real users nothing. Add `armeabi-v7a` only if
+  you want very old 32-bit devices (verify the native build links there first).
+- **Bundled starters**: *The Down Dragon* and *The Unholy Grail* ship inside the
+  app (`app/src/main/assets/`). Confirm you're happy distributing those, and
+  consider whether the content rating should reflect Dragon's themes.
+- **`minSdk 29`** (Android 10) covers the large majority of active tablets and
+  is required by RemGlk's `timespec_get`. Lower would need a shim.
+
+## Distributing without Google Play (sideload)
+
+```sh
+./gradlew :app:assembleRelease       # signed APK
+```
+Share `app-release.apk`; users enable "install unknown apps" for the source.
+No store listing, rating, or review needed — but also no auto-updates.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,7 +1,20 @@
+import java.io.FileInputStream
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
+}
+
+// Release signing is configured from keystore.properties (gitignored), so no
+// keystore or passwords live in the repo. If the file is absent (a fresh clone,
+// CI, or anyone who only builds debug) the release build is simply left
+// unsigned -- the project still configures and assembleDebug still works.
+// See keystore.properties.example and README.md for the one-time setup.
+val keystorePropertiesFile = rootProject.file("keystore.properties")
+val keystoreProperties = Properties().apply {
+    if (keystorePropertiesFile.exists()) FileInputStream(keystorePropertiesFile).use { load(it) }
 }
 
 android {
@@ -33,10 +46,26 @@ android {
         }
     }
 
+    signingConfigs {
+        if (keystorePropertiesFile.exists()) {
+            create("release") {
+                storeFile = rootProject.file(keystoreProperties.getProperty("storeFile"))
+                storePassword = keystoreProperties.getProperty("storePassword")
+                keyAlias = keystoreProperties.getProperty("keyAlias")
+                keyPassword = keystoreProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            // Sign with the release key when configured; otherwise leave the
+            // release artifact unsigned (you can sign it later with apksigner).
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,11 @@
+# ProGuard / R8 rules for the release build.
+#
+# Minification is currently disabled (isMinifyEnabled = false), so these rules
+# are not applied today; the file exists so the release buildType's
+# proguardFiles reference resolves, and as the place to add keep-rules if R8 is
+# enabled later. The native interface is JNI-bound by exact name from
+# android_jni.c, so if you enable R8 keep the bridge entry points:
+#
+# -keepclasseswithmembernames class au.com.dangarmarine.jacl.GlkBridge {
+#     native <methods>;
+# }

--- a/android/keystore.properties.example
+++ b/android/keystore.properties.example
@@ -1,0 +1,20 @@
+# Release signing config for the JACL Android app.
+#
+# 1. Create a release keystore once (keep it and these passwords safe and
+#    OUT of version control -- they identify you as the app's publisher):
+#
+#      keytool -genkeypair -v -keystore jacl-release.jks -alias jacl \
+#              -keyalg RSA -keysize 2048 -validity 10000
+#
+# 2. Copy this file to  android/keystore.properties  (already gitignored) and
+#    fill in the real values. storeFile is resolved relative to android/.
+#
+# With keystore.properties present:
+#   ./gradlew :app:assembleRelease   -> signed release APK
+#   ./gradlew :app:bundleRelease     -> signed AAB (for Google Play upload)
+# Without it, the release build is left unsigned.
+
+storeFile=jacl-release.jks
+storePassword=CHANGE_ME
+keyAlias=jacl
+keyPassword=CHANGE_ME


### PR DESCRIPTION
Adds standard release signing for the Android app, with **no secrets in the repo**.

- **`app/build.gradle.kts`** reads `keystore.properties` (gitignored) and signs the `release` build type with it. If the file is absent (fresh clone / CI / debug-only), the release build still configures and is simply left unsigned; `assembleDebug` is unaffected.
- **`keystore.properties.example`** — template + the `keytool` command to create a keystore.
- **`.gitignore`** now excludes `keystore.properties`, `*.jks`, `*.keystore`.
- **`app/proguard-rules.pro`** — added (release type references it; documents the JNI keep-rule for if R8 is enabled).
- **`README.md`** — debug build + release-signing steps.

### Verified
With a throwaway keystore:
- `assembleRelease` → **signed** APK (`apksigner`: `CN=JACL, O=Dangar Marine, C=AU`)
- `bundleRelease` → **signed** AAB (for Google Play)

🤖 Generated with [Claude Code](https://claude.com/claude-code)