### PR TITLE
Android: hide the bare trailing ">" prompt in the transcript

### DIFF
--- a/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
@@ -428,10 +428,19 @@ fun TranscriptView(
     LaunchedEffect(paras.size, paras.lastOrNull()?.spans?.sumOf { it.text.length }) {
         scroll.scrollTo(scroll.maxValue)
     }
+    // While waiting for a command, JACL has already written its bare "> " prompt
+    // as the trailing paragraph. Hide it -- the input bar below is the live
+    // prompt, and the command is echoed ("> look") on submit. Only drop a
+    // genuinely short non-image trailing line, so real output is never removed.
+    val visible = if (bridge.pendingInput?.type == "line" && paras.isNotEmpty() &&
+        paras.last().spans.all { it.image == null } &&
+        paras.last().spans.joinToString("") { it.text }.trim().length <= 2) {
+        paras.dropLast(1)
+    } else paras
     var bannerShown = false
     val accent = MaterialTheme.colorScheme.primary
     Column(Modifier.fillMaxSize().verticalScroll(scroll).padding(vertical = 12.dp)) {
-        for (p in paras) {
+        for (p in visible) {
             val img = p.spans.firstOrNull { it.image != null }?.image
             if (img != null) {
                 if (!bannerShown) { BannerImage(bridge, img, headerColor); bannerShown = true }


### PR DESCRIPTION
The transcript showed a stray `> ` line under the latest text — JACL's bare prompt, written while it waits for input. The input bar at the bottom is already the live prompt, so it's redundant (and the iOS app already removes it).

Drops a short (≤2 char) non-image trailing paragraph when at a `line` prompt — the same rule as iOS, so the apps stay consistent. (The alternative — an inline cursor after the `>` like the console — was an option too; went with hide-it to match the iPad.)

Verified on the emulator: the transcript ends at the last game line, with only the input-bar `>` below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)