### PR TITLE
Serve .jaclgame as a dedicated MIME so Android can open downloads

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,11 +23,21 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <!-- Open a .jaclgame / .j2 from Files, a download, or a share.
-                 mimeType="*/*" + pathPattern is the standard recipe for a custom
-                 extension over content:// and file:// schemes. Pinning a specific
-                 MIME (e.g. application/octet-stream) misses whatever the browser
-                 or Files app actually reports for the download. -->
+            <!-- A browser download opens via an opaque content:// uri (no
+                 filename in the path), so match it by the dedicated MIME the
+                 server sends for .jaclgame (see etc/jacl-apache.conf). -->
+            <intent-filter android:label="@string/open_in_jacl">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:scheme="file" />
+                <data android:mimeType="application/x-jaclgame" />
+            </intent-filter>
+
+            <!-- Open a .jaclgame / .j2 by extension (Files / file:// / a share
+                 whose uri keeps the name). mimeType="*/*" + pathPattern is the
+                 standard recipe for a custom extension. -->
             <intent-filter android:label="@string/open_in_jacl">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/etc/jacl-apache.conf
+++ b/etc/jacl-apache.conf
@@ -30,16 +30,21 @@
 </IfModule>
 
 # ----------------------------------------------------------------------
-# iPad download packages (.jaclgame)
+# Game download packages (.jaclgame)
 #
-# A .jaclgame is a ZIP, so with no explicit Content-Type iOS sniffs the
-# magic bytes and serves it as a generic .zip -- which the JACL app doesn't
-# own, so "Open in JACL" never appears on download. Serve it as an opaque
-# binary attachment so Safari keeps the .jaclgame name; the installed app
-# then matches it by extension and offers to open it.
+# A .jaclgame is a ZIP, but it must NOT be served as application/zip (iOS would
+# sniff it as a generic .zip the JACL app doesn't own) nor as a generic
+# application/octet-stream (Android can't tell a downloaded octet-stream apart
+# from any other binary, so "Open in JACL" never appears for it). Serve it as a
+# dedicated type, application/x-jaclgame, which BOTH apps register for:
+#   * iOS matches the .jaclgame extension (kept via Content-Disposition) and
+#     this MIME via its exported UTI;
+#   * Android registers an intent filter for application/x-jaclgame, so a
+#     download opened from the browser/Files offers JACL even though its
+#     content:// uri has no usable filename.
 # ----------------------------------------------------------------------
 <LocationMatch "\.jaclgame$">
-  ForceType application/octet-stream
+  ForceType application/x-jaclgame
   <IfModule mod_headers.c>
     Header set Content-Disposition "attachment"
   </IfModule>

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -143,3 +143,5 @@ targets:
             UTTypeTagSpecification:
               public.filename-extension:
                 - jaclgame
+              public.mime-type:
+                - application/x-jaclgame


### PR DESCRIPTION
**Problem:** downloading a game in the Android browser and tapping **Open** didn't open it in JACL (it just re-opened the page). A downloaded `.jaclgame` opens via an opaque `content://` uri with no filename in the path, so the app's extension-based filter can't match it, and the old `application/octet-stream` is too generic to register a handler. (iOS was fine — Safari keeps the filename and iOS matches by extension.)

**Fix:** serve `.jaclgame` as a **dedicated type, `application/x-jaclgame`**, that both apps register for.

| File | Change |
|------|--------|
| `etc/jacl-apache.conf` | `ForceType application/x-jaclgame` (was `octet-stream`), keeping `Content-Disposition: attachment` |
| `AndroidManifest.xml` | a `content://` intent filter matching `application/x-jaclgame` (alongside the existing extension filter for Files/`file://`) |
| `ios/project.yml` | declare `public.mime-type: application/x-jaclgame` on the jaclgame UTI |

**Verified (Android):** `pm query-activities` lists JACL for `application/x-jaclgame`; firing that VIEW intent launched JACL and imported the game.

**iOS is safe:** it matches `.jaclgame` by extension, so the server change doesn't affect the already-deployed iPad app (Safari still downloads `x.jaclgame` by name). The UTI MIME line is robustness and lands on the next `xcodegen` regen.

### Rollout
- **Server:** `git pull && ./configure && make apache` to pick up the new Content-Type. *(Existing downloads cached by browsers may need a fresh fetch.)*
- **Android:** install the new build (registers the MIME filter).
- **iOS:** no action needed; optional `xcodegen` regen to add the UTI MIME.

🤖 Generated with [Claude Code](https://claude.com/claude-code)