### PR TITLE
Android: stop the command line autocorrecting game words

### DIFF
--- a/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -542,9 +543,16 @@ fun InputBar(bridge: GlkBridge, fontSize: Float) {
                     textStyle = TextStyle(fontSize = fontSize.sp, color = MaterialTheme.colorScheme.onSurface),
                     cursorBrush = SolidColor(MaterialTheme.colorScheme.onSurface),
                     singleLine = true,
+                    // A password-type IME reliably disables autocorrect and
+                    // suggestions on every keyboard (autoCorrect=false alone is
+                    // ignored by Gboard, which otherwise "corrects" non-English
+                    // game words like Indonesian "payung" to English). The text
+                    // stays visible -- Compose only masks via visualTransformation,
+                    // which we leave at its default (None).
                     keyboardOptions = KeyboardOptions(
                         autoCorrect = false,
                         capitalization = KeyboardCapitalization.None,
+                        keyboardType = KeyboardType.Password,
                         imeAction = ImeAction.Send,
                     ),
                     keyboardActions = KeyboardActions(onSend = { submit() }),


### PR DESCRIPTION
**Problem:** on a non-English game the command line autocorrects game words to English — e.g. Indonesian `ambil payung` → `ambil paying` — because Gboard uses the English dictionary. `autoCorrect = false` alone doesn't stop it (Gboard ignores it without `NO_SUGGESTIONS`).

**Fix:** give the command field a **password-type IME** (`KeyboardType.Password`), which every Android keyboard treats as no-autocorrect / no-suggestions — the equivalent of the iOS field's `.autocorrectionDisabled()`. The text stays **visible** (Compose only masks via `visualTransformation`, which we leave at the default `None`).

### Verification note
I couldn't verify the autocorrect suppression headlessly — `adb input` injects text *past* the keyboard's autocorrect engine, and a Compose field's IME input-type isn't exposed to `uiautomator`. I did confirm on the emulator that the typed text shows **in clear** (not masked). Please confirm on-device that typing `ambil payung` in `desa` no longer "corrects" it. If a keyboard still does, the fallback is a native field with the explicit `TYPE_TEXT_FLAG_NO_SUGGESTIONS`.

iOS is unaffected (it already disables autocorrect and works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)