### PR TITLE
iOS/Android: named save & restore

### DIFF
--- a/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
@@ -29,6 +29,11 @@ class RenderedParagraph(val spans: MutableList<RenderedSpan>)
 /** The pending input request the terp is waiting on. */
 data class GlkInput(val id: Int, val type: String)
 
+/** A pending save/restore file prompt: the game called save/restore and the
+ *  terp is waiting for a filename. [filemode] is "write" (saving) or "read"
+ *  (restoring). Mirrors the iOS GlkSpecialInput. */
+data class GlkSpecialInput(val filemode: String, val filetype: String)
+
 /** A window in the current layout (we only need id + kind). */
 data class GlkWindow(val id: Int, val type: String)
 
@@ -52,6 +57,19 @@ class GlkBridge {
         private const val TAG = "JACL"
         /** Interpreter version, read once for the shelf. */
         val version: String by lazy { GlkBridge().nativeVersion() }
+
+        /** Reserved base name for the silent per-game autosave slot, kept out
+         *  of the player's named-save list. */
+        const val AUTOSAVE_NAME = "__autosave__"
+
+        /** Base names (no ".glksave") of the saved games for [gameFile],
+         *  newest first. RemGlk writes saves next to the .j2; the reserved
+         *  autosave slot is excluded. */
+        fun savedGames(gameFile: java.io.File): List<String> =
+            (gameFile.parentFile?.listFiles { f -> f.extension == "glksave" } ?: emptyArray())
+                .sortedByDescending { it.lastModified() }
+                .map { it.nameWithoutExtension }
+                .filter { it != AUTOSAVE_NAME }
     }
 
     // --- Published display model (drives Compose) ---------------------------
@@ -59,6 +77,9 @@ class GlkBridge {
     var buffers by mutableStateOf<Map<Int, List<RenderedParagraph>>>(emptyMap()); private set
     var grids by mutableStateOf<Map<Int, List<List<RenderedSpan>>>>(emptyMap()); private set
     var pendingInput by mutableStateOf<GlkInput?>(null); private set
+    /** A pending save/restore file prompt, if the game is waiting for a
+     *  filename. Drives the name dialog / restore picker. */
+    var pendingFilePrompt by mutableStateOf<GlkSpecialInput?>(null); private set
     var finished by mutableStateOf(false); private set
 
     // --- Plumbing -----------------------------------------------------------
@@ -118,6 +139,18 @@ class GlkBridge {
             .put("window", req.id).put("value", value))
         pendingInput = null
     }
+
+    /** Answer a pending save/restore file prompt with [name] (a bare filename).
+     *  An empty [name] cancels the save/restore. */
+    fun submitFileref(name: String) {
+        if (pendingFilePrompt == null) return
+        enqueue(JSONObject().put("type", "specialresponse").put("gen", generation)
+            .put("response", "fileref_prompt").put("value", name))
+        pendingFilePrompt = null
+    }
+
+    /** Cancel a pending save/restore prompt (sends an empty filename). */
+    fun cancelFileref() = submitFileref("")
 
     fun resize(widthPx: Int, heightPx: Int, cellWidthPx: Double, cellHeightPx: Double) {
         sizeW = widthPx; sizeH = heightPx; cellW = cellWidthPx; cellH = cellHeightPx
@@ -243,6 +276,15 @@ class GlkBridge {
                 val inp = inputs.getJSONObject(0)
                 GlkInput(inp.getInt("id"), inp.optString("type"))
             } else null
+
+            // A save/restore prompt arrives as a top-level `specialinput`
+            // instead of a normal input request; surface it for the UI.
+            val special = update.optJSONObject("specialinput")
+            if (special != null && special.optString("type") == "fileref_prompt") {
+                pendingFilePrompt = GlkSpecialInput(
+                    filemode = special.optString("filemode", "read"),
+                    filetype = special.optString("filetype", "save"))
+            }
         } finally {
             awaiting = false
             pump()

--- a/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
@@ -352,6 +352,7 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
     }
 
     var showTextSize by remember { mutableStateOf(false) }
+    var saveName by remember { mutableStateOf("") }
 
     BackHandler(onBack = onBack)
     DisposableEffect(game.file.path) { onDispose { bridge.stop() } }
@@ -431,6 +432,59 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
             confirmButton = { TextButton(onClick = { definition = null }) { Text("Done") } },
             title = { Text(word) },
             text = { Text(gloss) },
+        )
+    }
+
+    // Save/restore file prompts. The game's save verb asks for a name (write);
+    // the restore verb shows the existing saves to pick from (read). Both
+    // answer the same RemGlk file prompt.
+    val prompt = bridge.pendingFilePrompt
+    if (prompt?.filemode == "write") {
+        AlertDialog(
+            onDismissRequest = { bridge.cancelFileref(); saveName = "" },
+            title = { Text("Save Game") },
+            text = {
+                OutlinedTextField(
+                    value = saveName,
+                    onValueChange = { saveName = it },
+                    singleLine = true,
+                    label = { Text("Save name") },
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = { bridge.submitFileref(saveName.trim()); saveName = "" }) {
+                    Text("Save")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { bridge.cancelFileref(); saveName = "" }) { Text("Cancel") }
+            },
+        )
+    } else if (prompt?.filemode == "read") {
+        val saves = remember(prompt) { GlkBridge.savedGames(game.file) }
+        AlertDialog(
+            onDismissRequest = { bridge.cancelFileref() },
+            title = { Text("Restore Game") },
+            text = {
+                if (saves.isEmpty()) {
+                    Text("No saved games. Type “save” during play to create one.")
+                } else {
+                    Column {
+                        for (name in saves) {
+                            TextButton(
+                                onClick = { bridge.submitFileref(name) },
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text(name, Modifier.fillMaxWidth())
+                            }
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { bridge.cancelFileref() }) { Text("Cancel") }
+            },
         )
     }
 }

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -145,6 +145,8 @@ struct GameView: View {
     @FocusState private var inputFocused: Bool
     /// Whether the in-game text-size popover (the top-bar "Aa" button) is open.
     @State private var showTextSize = false
+    /// Working text for the "name this save" dialog.
+    @State private var saveName = ""
 
     // DEBUG-only scripted input (via `-autocommands "no;look;…"`), used to
     // exercise the bridge's input round-trip headlessly. Empty in release.
@@ -230,6 +232,45 @@ struct GameView: View {
                 }
             }
         }
+        // Saving: the game asked for a name (save verb). Restoring uses the
+        // picker below. Both answer the same RemGlk file prompt.
+        .alert("Save Game", isPresented: writePromptBinding) {
+            TextField("Save name", text: $saveName)
+                .textInputAutocapitalization(.never)
+            Button("Save") {
+                bridge.submitFileref(saveName.trimmingCharacters(in: .whitespaces))
+                saveName = ""
+            }
+            Button("Cancel", role: .cancel) { bridge.cancelFileref(); saveName = "" }
+        } message: {
+            Text("Name this saved game.")
+        }
+        .sheet(isPresented: readPromptBinding) {
+            RestorePicker(saves: GlkBridge.savedGames(forGamePath: gamePath),
+                          onPick: { bridge.submitFileref($0) },
+                          onCancel: { bridge.cancelFileref() })
+        }
+    }
+
+    /// True while the game is waiting for a save name (write-mode file prompt).
+    private var writePromptBinding: Binding<Bool> {
+        Binding(get: { bridge.pendingFilePrompt?.filemode == "write" },
+                set: { show in
+                    if !show, bridge.pendingFilePrompt?.filemode == "write" {
+                        bridge.cancelFileref()
+                    }
+                })
+    }
+
+    /// True while the game is waiting for a save to restore (read-mode prompt).
+    /// Swiping the picker away cancels the restore.
+    private var readPromptBinding: Binding<Bool> {
+        Binding(get: { bridge.pendingFilePrompt?.filemode == "read" },
+                set: { show in
+                    if !show, bridge.pendingFilePrompt?.filemode == "read" {
+                        bridge.cancelFileref()
+                    }
+                })
     }
 
     /// Parse `-autocommands "no;look;…"` from the launch args (DEBUG only).
@@ -378,6 +419,43 @@ private struct TextSizePopover: View {
         .padding()
         .frame(width: 280)
         .presentationCompactAdaptation(.popover)
+    }
+}
+
+// MARK: - Restore picker
+
+/// A list of the game's saved games, shown when the player types "restore".
+/// Picking one answers the file prompt with its name; the bundled binding
+/// cancels the restore if the sheet is dismissed without a choice.
+private struct RestorePicker: View {
+    let saves: [String]
+    let onPick: (String) -> Void
+    let onCancel: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if saves.isEmpty {
+                    ContentUnavailableView("No Saved Games", systemImage: "tray",
+                        description: Text("Type “save” during play to create one."))
+                } else {
+                    List(saves, id: \.self) { name in
+                        Button { onPick(name); dismiss() } label: {
+                            Label(name, systemImage: "doc")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Restore Game")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { onCancel(); dismiss() }
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
     }
 }
 

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -43,6 +43,9 @@ final class GlkBridge: ObservableObject {
     @Published var grids: [Int: [[RenderedSpan]]] = [:]
     /// The pending input request, if the terp is waiting for one.
     @Published var pendingInput: GlkInput?
+    /// A pending save/restore file prompt, if the game called save/restore and
+    /// is waiting for a filename. Drives the name dialog / restore picker.
+    @Published var pendingFilePrompt: GlkSpecialInput?
     /// Set when the game has quit (terp thread ended / socket closed).
     @Published var finished = false
 
@@ -149,6 +152,17 @@ final class GlkBridge: ObservableObject {
         pendingInput = nil
     }
 
+    /// Answer a pending save/restore file prompt with `name` (a bare filename
+    /// the player chose). An empty `name` cancels the save/restore.
+    func submitFileref(_ name: String) {
+        guard pendingFilePrompt != nil else { return }
+        enqueue(.specialResponse(gen: generation, value: name))
+        pendingFilePrompt = nil
+    }
+
+    /// Cancel a pending save/restore prompt (sends an empty filename).
+    func cancelFileref() { submitFileref("") }
+
     /// Tell the terp the display resized (e.g. rotation, split view, keyboard).
     func resize(to size: CGSize) {
         enqueue(.arrange(gen: generation, metrics: metrics(for: size)))
@@ -251,7 +265,37 @@ final class GlkBridge: ObservableObject {
         }
 
         pendingInput = update.input?.first
+        // A save/restore file prompt arrives as a top-level `specialinput`
+        // instead of a normal line/char request; surface it for the UI to
+        // answer (name dialog when writing, picker when reading).
+        if let si = update.specialinput, si.type == "fileref_prompt" {
+            pendingFilePrompt = si
+        }
     }
+
+    // MARK: Saved games
+
+    /// Base names (no ".glksave") of the saved games for the game at
+    /// `gamePath`, newest first. RemGlk writes saves next to the .j2 in the
+    /// sandbox; the reserved autosave slot is excluded.
+    static func savedGames(forGamePath gamePath: String) -> [String] {
+        let dir = (gamePath as NSString).deletingLastPathComponent
+        let fm = FileManager.default
+        let files = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
+        return files
+            .filter { $0.hasSuffix(".glksave") }
+            .map { String($0.dropLast(".glksave".count)) }
+            .filter { $0 != GlkBridge.autosaveName }
+            .sorted { lhs, rhs in
+                let l = (try? fm.attributesOfItem(atPath: "\(dir)/\(lhs).glksave")[.modificationDate]) as? Date
+                let r = (try? fm.attributesOfItem(atPath: "\(dir)/\(rhs).glksave")[.modificationDate]) as? Date
+                return (l ?? .distantPast) > (r ?? .distantPast)
+            }
+    }
+
+    /// The reserved base name for the silent per-game autosave slot, kept out
+    /// of the player's named-save list.
+    static let autosaveName = "__autosave__"
 
     private func render(_ span: GlkSpan) -> RenderedSpan {
         RenderedSpan(text: span.text ?? "",

--- a/ios/JACL/RemGlkProtocol.swift
+++ b/ios/JACL/RemGlkProtocol.swift
@@ -19,8 +19,18 @@ struct GlkUpdate: Decodable {
     let windows: [GlkWindow]?
     let content: [GlkContent]?
     let input: [GlkInput]?
+    let specialinput: GlkSpecialInput?   // present when the game prompts for a file (save/restore)
     let disable: Bool?
     let message: String?          // present on {"type":"error","message":…}
+}
+
+/// A file-reference prompt: the game called save/restore and RemGlk is waiting
+/// for a filename. `filemode` is "write" (saving) or "read" (restoring);
+/// `filetype` is "save" for the save/restore verbs.
+struct GlkSpecialInput: Decodable, Equatable {
+    let type: String              // "fileref_prompt"
+    let filemode: String?         // "write" | "read" | "readwrite" | "writeappend"
+    let filetype: String?         // "save" | "transcript" | "command" | "data"
 }
 
 /// Geometry + kind of one window. Coordinates are in the same units we send
@@ -107,6 +117,11 @@ enum GlkEvent {
     case char(gen: Int, window: Int, value: String)
     case hyperlink(gen: Int, window: Int, value: Int)
     case redraw(gen: Int)
+    /// Answer a `fileref_prompt` (save/restore). `value` is the bare filename
+    /// the player chose; RemGlk confines it to the game's sandbox dir and
+    /// appends ".glksave". An empty value cancels (no file -> the game reports
+    /// it couldn't save/restore).
+    case specialResponse(gen: Int, value: String)
 
     private var dictionary: [String: Any] {
         switch self {
@@ -123,6 +138,9 @@ enum GlkEvent {
             return ["type": "hyperlink", "gen": gen, "window": window, "value": value]
         case let .redraw(gen):
             return ["type": "redraw", "gen": gen]
+        case let .specialResponse(gen, value):
+            return ["type": "specialresponse", "gen": gen,
+                    "response": "fileref_prompt", "value": value]
         }
     }
 
@@ -143,6 +161,7 @@ enum GlkEvent {
         case let .char(_, w, v):      return .char(gen: gen, window: w, value: v)
         case let .hyperlink(_, w, v): return .hyperlink(gen: gen, window: w, value: v)
         case .redraw:                 return .redraw(gen: gen)
+        case let .specialResponse(_, v): return .specialResponse(gen: gen, value: v)
         }
     }
 


### PR DESCRIPTION
Stage 1 of the save/resume work: make the **save / restore verbs** work in both apps.

## Why
`save`/`restore` call a Glk fileref-by-prompt, which RemGlk surfaces over the socket as a top-level `"specialinput":{"type":"fileref_prompt",…}`. Neither bridge answered it, so those verbs would hang. This wires up the round-trip and adds the UI.

## What
- **Both bridges:** decode the `specialinput` file prompt and publish it (`pendingFilePrompt`); add a `specialresponse` event replying with the chosen filename (an empty value cancels).
- **iOS:** a "Save Game" name alert (write mode) and a restore-picker sheet (read mode) in `GameView`, listing `<name>.glksave` files next to the `.j2`.
- **Android:** the same as a name dialog + restore-picker dialog in `GameScreen`.
- Saves land in the game's sandbox dir as `<name>.glksave` (RemGlk confines the name to the sandbox and appends the suffix). A reserved `__autosave__` slot name is filtered out of the player's list — groundwork for the autosave/resume PR to follow.

## Verified
Android emulator, full round-trip:
- `save` → name dialog → writes `tavern.glksave` (34 KB) next to `dragon.j2` → "Game saved."
- `restore` → picker lists "tavern" → "Restored saved game."

iOS builds clean (`xcodebuild` simulator) and is a direct mirror of the same protocol + UI; installed on the JACL-iPad sim for hands-on testing.

## Follow-up (next PR)
Silent per-game autosave on exit + resume on reopen (full game state) + a Restart control — reuses this machinery plus a small `jacl.c` resume hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)