### PR TITLE
iOS/Android: silent autosave + resume, per-game saves, Restart

### DIFF
--- a/android/app/src/main/cpp/android_jni.c
+++ b/android/app/src/main/cpp/android_jni.c
@@ -97,3 +97,12 @@ Java_au_com_dangarmarine_jacl_GlkBridge_nativeVersion(JNIEnv *env, jobject thiz)
 {
     return (*env)->NewStringUTF(env, jacl_interpreter_version());
 }
+
+/* void nativeSetAutosaveSuppressed(boolean) -> suppress/allow the autosave that
+ * fires when the game's socket closes. Kotlin sets it true before a Restart
+ * closes the socket so the discarded game isn't autosaved over. */
+JNIEXPORT void JNICALL
+Java_au_com_dangarmarine_jacl_GlkBridge_nativeSetAutosaveSuppressed(JNIEnv *env, jobject thiz, jboolean suppressed)
+{
+    jacl_autosave_set_suppressed(suppressed ? 1 : 0);
+}

--- a/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
@@ -51,6 +51,10 @@ class GlkBridge {
     private external fun nativeStart(gamePath: String): Int
     external fun nativeImage(num: Int): ByteArray?
     external fun nativeVersion(): String
+    private external fun nativeSetAutosaveSuppressed(suppressed: Boolean)
+
+    /** Suppress/allow the autosave that fires when the socket closes (Restart). */
+    fun setAutosaveSuppressed(suppressed: Boolean) = nativeSetAutosaveSuppressed(suppressed)
 
     companion object {
         init { System.loadLibrary("jacl") }
@@ -58,18 +62,34 @@ class GlkBridge {
         /** Interpreter version, read once for the shelf. */
         val version: String by lazy { GlkBridge().nativeVersion() }
 
-        /** Reserved base name for the silent per-game autosave slot, kept out
-         *  of the player's named-save list. */
-        const val AUTOSAVE_NAME = "__autosave__"
+        // Every game shares one sandbox dir, so all of a game's saves are
+        // prefixed with its base name ("<base>_"): a save "start" becomes
+        // "dragon_start.glksave", so the same name works across games. The
+        // autosave slot is "<base>__auto.glksave", excluded from the list.
+        // These must match the interpreter's `prefix` (the .j2 basename).
 
-        /** Base names (no ".glksave") of the saved games for [gameFile],
-         *  newest first. RemGlk writes saves next to the .j2; the reserved
-         *  autosave slot is excluded. */
-        fun savedGames(gameFile: java.io.File): List<String> =
-            (gameFile.parentFile?.listFiles { f -> f.extension == "glksave" } ?: emptyArray())
+        /** The game's base name, e.g. "dragon" for "dragon.j2". */
+        fun gameBase(gameFile: java.io.File): String = gameFile.nameWithoutExtension
+
+        /** The game's silent autosave slot file. */
+        fun autosaveFile(gameFile: java.io.File): java.io.File =
+            java.io.File(gameFile.parentFile, gameBase(gameFile) + "__auto.glksave")
+
+        /** The fileref value to send for a player-entered save [name]. */
+        fun saveValue(gameFile: java.io.File, name: String): String =
+            gameBase(gameFile) + "_" + name
+
+        /** Display names (game prefix stripped, autosave excluded) of this
+         *  game's named saves, newest first. */
+        fun savedGames(gameFile: java.io.File): List<String> {
+            val prefix = gameBase(gameFile) + "_"
+            val autoBare = gameBase(gameFile) + "__auto"
+            return (gameFile.parentFile?.listFiles { f -> f.extension == "glksave" } ?: emptyArray())
                 .sortedByDescending { it.lastModified() }
                 .map { it.nameWithoutExtension }
-                .filter { it != AUTOSAVE_NAME }
+                .filter { it.startsWith(prefix) && it != autoBare }
+                .map { it.removePrefix(prefix) }
+        }
     }
 
     // --- Published display model (drives Compose) ---------------------------
@@ -92,7 +112,9 @@ class GlkBridge {
     /** RemGlk wants exactly one event per update; queue while awaiting. */
     private var awaiting = false
     private val outQueue = ArrayDeque<JSONObject>()
-    private val splitter = JsonObjectStream()
+    private var splitter = JsonObjectStream()
+    /** Remembered launch args so the game can be restarted in place. */
+    private var gamePath = ""
 
     private var fontSize = 17.0
     /** Status-grid cell metrics are measured at this size by the UI and set
@@ -107,7 +129,12 @@ class GlkBridge {
     /** Launch [gamePath] and send the initial metrics for the given pixel size
      *  and measured monospaced cell. */
     fun start(gamePath: String, widthPx: Int, heightPx: Int, cellWidthPx: Double, cellHeightPx: Double) {
+        this.gamePath = gamePath
         sizeW = widthPx; sizeH = heightPx; cellW = cellWidthPx; cellH = cellHeightPx
+        // Reset state so this is safe to call again for a Restart (fresh terp).
+        windows = emptyList(); buffers = emptyMap(); grids = emptyMap()
+        pendingInput = null; pendingFilePrompt = null; finished = false
+        generation = 0; awaiting = false; outQueue.clear(); splitter = JsonObjectStream()
         val appFd = nativeStart(gamePath)
         if (appFd < 0) { Log.e(TAG, "nativeStart failed"); finished = true; return }
         val descriptor = ParcelFileDescriptor.adoptFd(appFd)
@@ -122,6 +149,15 @@ class GlkBridge {
         try { pfd?.close() } catch (_: Exception) {}
         pfd = null
         finished = true
+    }
+
+    /** Restart the current game from scratch (Restart control). The caller first
+     *  suppresses the autosave and deletes the slot, so the relaunched terp
+     *  finds no autosave and runs the intro fresh. */
+    fun restart() {
+        if (gamePath.isEmpty()) return
+        stop()
+        start(gamePath, sizeW, sizeH, cellW, cellH)
     }
 
     fun submitLine(value: String) {

--- a/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -353,6 +354,7 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
 
     var showTextSize by remember { mutableStateOf(false) }
     var saveName by remember { mutableStateOf("") }
+    var showRestartConfirm by remember { mutableStateOf(false) }
 
     BackHandler(onBack = onBack)
     DisposableEffect(game.file.path) { onDispose { bridge.stop() } }
@@ -370,6 +372,10 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
                     IconButton(onClick = onBack) { Icon(Icons.AutoMirrored.Filled.ArrowBack, "Back") }
                 },
                 actions = {
+                    // Restart: wipe the autosave and begin again from the intro.
+                    IconButton(onClick = { showRestartConfirm = true }) {
+                        Icon(Icons.Filled.Refresh, "Restart game")
+                    }
                     // An "Aa" button that drops the text-size slider, so the
                     // reading size can be changed without leaving the game.
                     Box {
@@ -452,9 +458,12 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
                 )
             },
             confirmButton = {
-                TextButton(onClick = { bridge.submitFileref(saveName.trim()); saveName = "" }) {
-                    Text("Save")
-                }
+                TextButton(onClick = {
+                    // Prefix with the game so the same name works across games.
+                    val n = saveName.trim()
+                    bridge.submitFileref(if (n.isEmpty()) "" else GlkBridge.saveValue(game.file, n))
+                    saveName = ""
+                }) { Text("Save") }
             },
             dismissButton = {
                 TextButton(onClick = { bridge.cancelFileref(); saveName = "" }) { Text("Cancel") }
@@ -472,7 +481,7 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
                     Column {
                         for (name in saves) {
                             TextButton(
-                                onClick = { bridge.submitFileref(name) },
+                                onClick = { bridge.submitFileref(GlkBridge.saveValue(game.file, name)) },
                                 modifier = Modifier.fillMaxWidth(),
                             ) {
                                 Text(name, Modifier.fillMaxWidth())
@@ -484,6 +493,30 @@ fun GameScreen(game: Game, prefs: AppPrefs, onBack: () -> Unit) {
             confirmButton = {},
             dismissButton = {
                 TextButton(onClick = { bridge.cancelFileref() }) { Text("Cancel") }
+            },
+        )
+    }
+
+    if (showRestartConfirm) {
+        AlertDialog(
+            onDismissRequest = { showRestartConfirm = false },
+            title = { Text("Restart Game?") },
+            text = {
+                Text("Start over from the beginning. Your current progress (the " +
+                     "autosave) is lost; named saves are kept.")
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showRestartConfirm = false
+                    // Don't autosave the discarded game, drop its autosave slot,
+                    // then relaunch the terp so it runs the intro fresh.
+                    bridge.setAutosaveSuppressed(true)
+                    GlkBridge.autosaveFile(game.file).delete()
+                    bridge.restart()
+                }) { Text("Restart") }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRestartConfirm = false }) { Text("Cancel") }
             },
         )
     }

--- a/ios/JACL/ContentView.swift
+++ b/ios/JACL/ContentView.swift
@@ -147,6 +147,8 @@ struct GameView: View {
     @State private var showTextSize = false
     /// Working text for the "name this save" dialog.
     @State private var saveName = ""
+    /// Whether the "restart this game?" confirmation is showing.
+    @State private var showRestartConfirm = false
 
     // DEBUG-only scripted input (via `-autocommands "no;look;…"`), used to
     // exercise the bridge's input round-trip headlessly. Empty in release.
@@ -231,6 +233,13 @@ struct GameView: View {
                     TextSizePopover(fontSize: $transcriptFontSize)
                 }
             }
+            // Restart: wipe the autosave and begin the game again from the intro.
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showRestartConfirm = true } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .accessibilityLabel("Restart game")
+            }
         }
         // Saving: the game asked for a name (save verb). Restoring uses the
         // picker below. Both answer the same RemGlk file prompt.
@@ -238,7 +247,10 @@ struct GameView: View {
             TextField("Save name", text: $saveName)
                 .textInputAutocapitalization(.never)
             Button("Save") {
-                bridge.submitFileref(saveName.trimmingCharacters(in: .whitespaces))
+                let n = saveName.trimmingCharacters(in: .whitespaces)
+                // Prefix with the game so the same name works across games; an
+                // empty name cancels.
+                bridge.submitFileref(n.isEmpty ? "" : GlkBridge.saveValue(forGamePath: gamePath, name: n))
                 saveName = ""
             }
             Button("Cancel", role: .cancel) { bridge.cancelFileref(); saveName = "" }
@@ -247,8 +259,20 @@ struct GameView: View {
         }
         .sheet(isPresented: readPromptBinding) {
             RestorePicker(saves: GlkBridge.savedGames(forGamePath: gamePath),
-                          onPick: { bridge.submitFileref($0) },
+                          onPick: { bridge.submitFileref(GlkBridge.saveValue(forGamePath: gamePath, name: $0)) },
                           onCancel: { bridge.cancelFileref() })
+        }
+        .alert("Restart Game?", isPresented: $showRestartConfirm) {
+            Button("Restart", role: .destructive) {
+                // Don't autosave the game we're discarding, drop its autosave
+                // slot, then relaunch the terp so it runs the intro fresh.
+                jacl_autosave_set_suppressed(1)
+                try? FileManager.default.removeItem(atPath: GlkBridge.autosavePath(forGamePath: gamePath))
+                bridge.restart()
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text("Start over from the beginning. Your current progress (the autosave) is lost; named saves are kept.")
         }
     }
 

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -51,6 +51,9 @@ final class GlkBridge: ObservableObject {
 
     private var appFD: Int32 = -1
     private var generation = 0
+    /// Remembered launch args so the game can be restarted in place.
+    private var gamePath = ""
+    private var lastSize = CGSize.zero
     /// RemGlk requires exactly one event per update. `awaiting` is true between
     /// sending an event and receiving the update it triggers; further events
     /// queue (with consecutive arranges coalesced) until then.
@@ -78,6 +81,14 @@ final class GlkBridge: ObservableObject {
     /// Launch `gamePath` (an absolute .j2 path in the sandbox) and send the
     /// initial metrics for a display of `size` points.
     func start(gamePath: String, size: CGSize) {
+        // Remember the launch args + reset all protocol/display state, so this
+        // is safe to call again for a Restart (fresh terp, generation back to 0).
+        self.gamePath = gamePath
+        self.lastSize = size
+        buffers = [:]; grids = [:]; windows = []
+        pendingInput = nil; pendingFilePrompt = nil; finished = false
+        generation = 0; awaiting = false
+        outQueue.removeAll(); splitter = JSONObjectStream()
         // Drop the previous game's cached blorb images -- the cache is keyed by
         // resource number, so this game's image 1 would otherwise show the last
         // game's image 1 (grail rendering the Down Dragon banner).
@@ -162,6 +173,15 @@ final class GlkBridge: ObservableObject {
 
     /// Cancel a pending save/restore prompt (sends an empty filename).
     func cancelFileref() { submitFileref("") }
+
+    /// Restart the current game from scratch (used by the Restart control).
+    /// The caller first suppresses the autosave and deletes the slot, so the
+    /// relaunched terp finds no autosave and runs the intro fresh.
+    func restart() {
+        guard !gamePath.isEmpty else { return }
+        stop()
+        start(gamePath: gamePath, size: lastSize)
+    }
 
     /// Tell the terp the display resized (e.g. rotation, split view, keyboard).
     func resize(to size: CGSize) {
@@ -273,29 +293,50 @@ final class GlkBridge: ObservableObject {
         }
     }
 
-    // MARK: Saved games
+    // MARK: Saved games (per-game namespaced)
 
-    /// Base names (no ".glksave") of the saved games for the game at
-    /// `gamePath`, newest first. RemGlk writes saves next to the .j2 in the
-    /// sandbox; the reserved autosave slot is excluded.
-    static func savedGames(forGamePath gamePath: String) -> [String] {
-        let dir = (gamePath as NSString).deletingLastPathComponent
+    // Every game shares one sandbox dir, so all of a game's saves are prefixed
+    // with its base name ("<base>_"): a save called "start" becomes the file
+    // "dragon_start.glksave", letting the same name be reused across games
+    // without clashing. The autosave slot is "<base>__auto.glksave", excluded
+    // from the player's list. These must match the interpreter's `prefix`
+    // (the .j2 basename) — see jacl.c jacl_autosave_ref.
+
+    /// The game's base name, e.g. "dragon" for ".../dragon.j2".
+    static func gameBase(forGamePath p: String) -> String {
+        ((p as NSString).lastPathComponent as NSString).deletingPathExtension
+    }
+
+    /// The on-disk path of the game's silent autosave slot.
+    static func autosavePath(forGamePath p: String) -> String {
+        (p as NSString).deletingPathExtension + "__auto.glksave"
+    }
+
+    /// The fileref value to send for a player-entered save `name`.
+    static func saveValue(forGamePath p: String, name: String) -> String {
+        gameBase(forGamePath: p) + "_" + name
+    }
+
+    /// Display names (game prefix stripped, autosave excluded) of this game's
+    /// named saves, newest first.
+    static func savedGames(forGamePath p: String) -> [String] {
+        let dir = (p as NSString).deletingLastPathComponent
+        let base = gameBase(forGamePath: p)
+        let prefix = base + "_"
+        let autoBare = base + "__auto"
         let fm = FileManager.default
         let files = (try? fm.contentsOfDirectory(atPath: dir)) ?? []
         return files
             .filter { $0.hasSuffix(".glksave") }
-            .map { String($0.dropLast(".glksave".count)) }
-            .filter { $0 != GlkBridge.autosaveName }
+            .map { String($0.dropLast(".glksave".count)) }     // bare name
+            .filter { $0.hasPrefix(prefix) && $0 != autoBare }
             .sorted { lhs, rhs in
                 let l = (try? fm.attributesOfItem(atPath: "\(dir)/\(lhs).glksave")[.modificationDate]) as? Date
                 let r = (try? fm.attributesOfItem(atPath: "\(dir)/\(rhs).glksave")[.modificationDate]) as? Date
                 return (l ?? .distantPast) > (r ?? .distantPast)
             }
+            .map { String($0.dropFirst(prefix.count)) }        // strip "<base>_"
     }
-
-    /// The reserved base name for the silent per-game autosave slot, kept out
-    /// of the player's named-save list.
-    static let autosaveName = "__autosave__"
 
     private func render(_ span: GlkSpan) -> RenderedSpan {
         RenderedSpan(text: span.text ?? "",

--- a/ios/jacl_bridge.h
+++ b/ios/jacl_bridge.h
@@ -43,6 +43,12 @@ const char *jacl_interpreter_version(void);
  * jacl_bridge_run() may proceed. See jacl_bridge.c. */
 void jacl_bridge_mark_terp_exited(void);
 
+/* Suppress (1) or allow (0) the silent autosave that otherwise fires when the
+ * game's socket closes. The app sets this to 1 right before a Restart closes
+ * the socket, so the discarded game isn't autosaved over; each new game's
+ * glk_main resets it to 0. Defined in jacl.c (JACL_IOS_EMBED). */
+void jacl_autosave_set_suppressed(int suppressed);
+
 #ifdef __cplusplus
 }
 #endif

--- a/ios/remglk/rgdata.c
+++ b/ios/remglk/rgdata.c
@@ -570,9 +570,20 @@ static data_raw_t *data_raw_blockread_sub(FILE *file, char *termchar)
     *termchar = '\0';
 
     while (isspace(ch = getc(file))) { };
-    if (ch == EOF)
+    if (ch == EOF) {
+#ifdef JACL_IOS_EMBED
+        /* The app closed the socket: the player left while the game was parked
+         * waiting for the next command. Autosave so reopening resumes here
+         * (no-ops if nothing was played or a Restart suppressed it). Only on
+         * stdin -- reads of save/data files legitimately reach EOF. */
+        if (file == stdin) {
+            extern int jacl_autosave_save(void);
+            jacl_autosave_save();
+        }
+#endif
         gli_fatal_error("data: Unexpected end of input");
-    
+    }
+
     if (ch == ']' || ch == '}') {
         *termchar = ch;
         return NULL;

--- a/src/jacl.c
+++ b/src/jacl.c
@@ -187,12 +187,26 @@ static void jacl_strict_warning(const char *msg)
 	fprintf(stderr, "JACL error: %s\n", msg);
 }
 
+#ifdef JACL_IOS_EMBED
+/* Silent per-game autosave / resume, defined after restore_interaction below;
+ * forward-declared here because glk_main uses them. */
+extern volatile int jacl_autosave_suppressed;
+int jacl_autosave_save(void);
+int jacl_autosave_restore(void);
+#endif
+
 void
 glk_main(void)
 {
 	int             index;
 
 	frefid_t 		blorb_file;
+
+#ifdef JACL_IOS_EMBED
+	/* TRUE when this launch resumed a per-game autosave (see below): +intro is
+	 * skipped and the room is shown with +look_around instead of a fresh turn. */
+	int             jacl_resumed = FALSE;
+#endif
 
 	srand((int) time(NULL));
 
@@ -369,7 +383,18 @@ glk_main(void)
 
 	jacl_set_window(mainwin);
 
+#ifdef JACL_IOS_EMBED
+	/* Fresh launch: allow the next exit to autosave. Then, if this game has a
+	 * per-game autosave slot, resume it instead of replaying the intro -- the
+	 * restored state already holds everything +intro would set up. */
+	jacl_autosave_suppressed = FALSE;
+	jacl_resumed = jacl_autosave_restore();
+	if (!jacl_resumed) {
+		execute("+intro");
+	}
+#else
 	execute("+intro");
+#endif
 
 	if (object[2] == NULL) {
 		log_error (CANT_RUN, PLUS_STDERR);
@@ -379,7 +404,17 @@ glk_main(void)
     /* DUMMY RETRIEVE OF 'HERE' FOR TESTING OF GAME STATE */
     get_here();
 
+#ifdef JACL_IOS_EMBED
+	if (jacl_resumed) {
+		/* Show where the player is, full description, no turn passing
+		 * (+look_around does `set time = false`). */
+		execute("+look_around");
+	} else {
+		eachturn();
+	}
+#else
 	eachturn();
+#endif
 
 	/* TOP OF COMMAND LOOP */
 	do {
@@ -1464,6 +1499,74 @@ restore_interaction(const char *filename)
 		return (TRUE);
 	}
 }
+
+#ifdef JACL_IOS_EMBED
+/* ---- Silent per-game autosave / resume (iOS + Android apps only) -----------
+ *
+ * Mirrors how the web build persists state between commands: leaving a game
+ * (the app closes the socket, so the terp's stdin hits EOF) writes the current
+ * state to a reserved per-game slot "<prefix>__auto.glksave"; reopening the
+ * game restores it in glk_main -- skipping +intro and showing the room via
+ * +look_around -- so the player resumes exactly where they left off with no
+ * turn passing. Named saves the player makes are untouched.
+ *
+ * The slot is per-game (keyed on `prefix`, the .j2 basename) because every
+ * game shares one sandbox directory. An explicit Restart in the app sets the
+ * suppress flag so the next exit doesn't re-autosave, then deletes the slot. */
+
+volatile int jacl_autosave_suppressed = FALSE;
+
+static frefid_t jacl_autosave_ref(void)
+{
+	char name[120];
+	snprintf(name, sizeof(name), "%s__auto", prefix);
+	return glk_fileref_create_by_name(fileusage_SavedGame | fileusage_BinaryMode,
+	                                  name, 0);
+}
+
+/* Save current state to the autosave slot. No-ops unless a game is loaded and
+ * at least one turn has passed (so merely opening and closing a game, or
+ * leaving at the start-up "restore?" prompt, doesn't create a resume point).
+ * Called from the terp thread at the stdin-EOF boundary (rgdata.c), where the
+ * game is parked at a command prompt and its state is consistent. */
+int jacl_autosave_save(void)
+{
+	frefid_t ref;
+
+	if (jacl_autosave_suppressed) return (FALSE);
+	if (objects <= 0) return (FALSE);                         /* no game loaded */
+	if (TOTAL_MOVES == NULL || TOTAL_MOVES->value <= 0) return (FALSE);
+
+	ref = jacl_autosave_ref();
+	if (!ref) return (FALSE);
+	/* save_game() destroys the fileref itself once its stream is open, like
+	 * save_interaction does -- we must NOT destroy it again (double free). */
+	return (save_game(ref));
+}
+
+/* Restore the autosave slot if it exists. Returns TRUE if a game was resumed.
+ * Called from glk_main before +intro. */
+int jacl_autosave_restore(void)
+{
+	frefid_t ref = jacl_autosave_ref();
+
+	if (!ref) return (FALSE);
+	if (!glk_fileref_does_file_exist(ref)) {
+		glk_fileref_destroy(ref);   /* not consumed by restore_game below */
+		return (FALSE);
+	}
+	/* restore_game() destroys the fileref itself once its stream is open. */
+	return (restore_game(ref, FALSE));
+}
+
+/* Set by the app's Restart before it closes the socket, so the imminent exit
+ * doesn't write a fresh autosave over the one being discarded. Reset at the
+ * top of each new game's glk_main. */
+void jacl_autosave_set_suppressed(int suppressed)
+{
+	jacl_autosave_suppressed = suppressed;
+}
+#endif /* JACL_IOS_EMBED */
 
 glui32
 glk_get_bin_line_stream(strid_t file_stream, char *buffer, glui32 max_length)


### PR DESCRIPTION
Stage 2 of the save work. Reopening a game now continues exactly where you left off — the way the web build persists state between commands — plus per-game save scoping and a Restart control.

## Autosave / resume
Guarded by `JACL_IOS_EMBED`, so the console/web builds are untouched.
- **`jacl.c`** gains `jacl_autosave_save`/`jacl_autosave_restore`: `save_game`/`restore_game` to a reserved per-game slot `<prefix>__auto.glksave`. Save no-ops unless a game is loaded and a turn has passed (so merely opening/closing, or leaving at the start-up "restore?" prompt, makes no resume point).
- **`rgdata.c`** calls the autosave at the **stdin-EOF boundary** — i.e. when the app closes the socket on leaving, with the game parked at a command prompt and state consistent.
- **`glk_main`** restores the slot *before* `+intro`; on a resume it skips `+intro` and shows the room with `+look_around` (full description, **no turn passes**). This mirrors how the web build's `TOTAL_MOVES` gating skips the intro after a restore — so you land back at your last location with an auto-look.

Resume fidelity is **game state, fresh transcript** (as agreed): all progress restored; prior scrollback not re-rendered.

## Per-game save scoping
All saves are namespaced `<gamebase>_…` (games share one sandbox dir), so a name like **"start" works for every game without clashing**. The picker strips the prefix for display. `gamebase` matches the interpreter's `prefix` (the `.j2` basename).

## Restart
A top-bar **Restart** button on both apps suppresses the next autosave (`jacl_autosave_set_suppressed`, exposed via `jacl_bridge.h` + a JNI method), deletes the slot, and relaunches the terp so the game runs its intro fresh. Named saves are kept.

## Crash fixed during bring-up
`save_game`/`restore_game` already destroy the fileref once their stream opens, so the autosave helpers must **not** destroy it again — the double free aborted with a Scudo "corrupted chunk header". Fixed.

## Verified on the Android emulator
- Play → leave writes `dragon__auto.glksave`.
- Reopen → resumes at "The Rusty Sword Tavern", **no intro, no restore prompt**.
- Restart → wipes the slot, shows the fresh intro.
- Named save "start" → writes `dragon_start.glksave`, lists as **"start"**.

iOS builds clean and mirrors the same bridge + UI (the touch-driven save/resume/restart UI is hands-on to verify on the sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)