### PR TITLE
iOS/Android: honour Glk timer events (real-time games)

### DIFF
--- a/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
+++ b/android/app/src/main/java/au/com/dangarmarine/jacl/GlkBridge.kt
@@ -115,6 +115,10 @@ class GlkBridge {
     private var splitter = JsonObjectStream()
     /** Remembered launch args so the game can be restarted in place. */
     private var gamePath = ""
+    /** Current Glk timer interval in ms (0 = off). The game sets it via the
+     *  "timer" field of an update; we then post a {"type":"timer"} event every
+     *  interval until it's cancelled (a null "timer"). */
+    private var timerIntervalMs = 0
 
     private var fontSize = 17.0
     /** Status-grid cell metrics are measured at this size by the UI and set
@@ -146,9 +150,28 @@ class GlkBridge {
 
     /** Stop the terp: closing our socket end gives it EOF -> glk_exit. */
     fun stop() {
+        main.removeCallbacks(timerRunnable)
         try { pfd?.close() } catch (_: Exception) {}
         pfd = null
         finished = true
+    }
+
+    // --- Glk timer ----------------------------------------------------------
+    private val timerRunnable = object : Runnable {
+        override fun run() {
+            if (timerIntervalMs <= 0) return
+            // Coalesce: one pending tick at a time, so a slow turn can't make
+            // ticks pile up.
+            if (outQueue.none { it.optString("type") == "timer" }) {
+                enqueue(JSONObject().put("type", "timer").put("gen", generation))
+            }
+            main.postDelayed(this, timerIntervalMs.toLong())
+        }
+    }
+
+    private fun rescheduleTimer() {
+        main.removeCallbacks(timerRunnable)
+        if (timerIntervalMs > 0) main.postDelayed(timerRunnable, timerIntervalMs.toLong())
     }
 
     /** Restart the current game from scratch (Restart control). The caller first
@@ -320,6 +343,14 @@ class GlkBridge {
                 pendingFilePrompt = GlkSpecialInput(
                     filemode = special.optString("filemode", "read"),
                     filetype = special.optString("filetype", "save"))
+            }
+
+            // The "timer" field appears only when the game changes its timer:
+            // a number sets/restarts the interval, null cancels it. Absent =
+            // no change.
+            if (update.has("timer")) {
+                timerIntervalMs = if (update.isNull("timer")) 0 else update.getInt("timer")
+                rescheduleTimer()
             }
         } finally {
             awaiting = false

--- a/ios/JACL/GlkBridge.swift
+++ b/ios/JACL/GlkBridge.swift
@@ -54,6 +54,10 @@ final class GlkBridge: ObservableObject {
     /// Remembered launch args so the game can be restarted in place.
     private var gamePath = ""
     private var lastSize = CGSize.zero
+    /// Current Glk timer interval in ms (0 = off) and the repeating timer that
+    /// posts a {"type":"timer"} event each interval until the game cancels it.
+    private var timerIntervalMs = 0
+    private var glkTimer: Timer?
     /// RemGlk requires exactly one event per update. `awaiting` is true between
     /// sending an event and receiving the update it triggers; further events
     /// queue (with consecutive arranges coalesced) until then.
@@ -88,6 +92,7 @@ final class GlkBridge: ObservableObject {
         buffers = [:]; grids = [:]; windows = []
         pendingInput = nil; pendingFilePrompt = nil; finished = false
         generation = 0; awaiting = false
+        glkTimer?.invalidate(); glkTimer = nil; timerIntervalMs = 0
         outQueue.removeAll(); splitter = JSONObjectStream()
         // Drop the previous game's cached blorb images -- the cache is keyed by
         // resource number, so this game's image 1 would otherwise show the last
@@ -133,6 +138,7 @@ final class GlkBridge: ObservableObject {
     /// RemGlk's gli_initialize_windows() reset that state for a clean start --
     /// which is only safe because the previous terp has been stopped first.
     func stop() {
+        glkTimer?.invalidate(); glkTimer = nil; timerIntervalMs = 0
         let fd = appFD
         guard fd >= 0 else { return }
         appFD = -1
@@ -142,6 +148,7 @@ final class GlkBridge: ObservableObject {
     }
 
     deinit {
+        glkTimer?.invalidate()
         let fd = appFD
         if fd >= 0 {
             shutdown(fd, SHUT_RDWR)
@@ -290,6 +297,31 @@ final class GlkBridge: ObservableObject {
         // answer (name dialog when writing, picker when reading).
         if let si = update.specialinput, si.type == "fileref_prompt" {
             pendingFilePrompt = si
+        }
+        // The game changed its Glk timer: (re)start at the given interval, or
+        // cancel. Absent (update.timer == nil) means no change.
+        if let t = update.timer {
+            switch t {
+            case .set(let ms): timerIntervalMs = ms
+            case .cancel:      timerIntervalMs = 0
+            }
+            rescheduleTimer()
+        }
+    }
+
+    // MARK: Glk timer
+
+    private func rescheduleTimer() {
+        glkTimer?.invalidate()
+        glkTimer = nil
+        guard timerIntervalMs > 0 else { return }
+        glkTimer = Timer.scheduledTimer(withTimeInterval: Double(timerIntervalMs) / 1000.0,
+                                        repeats: true) { [weak self] _ in
+            guard let self else { return }
+            // Coalesce: at most one pending tick, so a slow turn can't pile them up.
+            if !self.outQueue.contains(where: { $0.isTimer }) {
+                self.enqueue(.timer(gen: self.generation))
+            }
         }
     }
 

--- a/ios/JACL/RemGlkProtocol.swift
+++ b/ios/JACL/RemGlkProtocol.swift
@@ -22,6 +22,38 @@ struct GlkUpdate: Decodable {
     let specialinput: GlkSpecialInput?   // present when the game prompts for a file (save/restore)
     let disable: Bool?
     let message: String?          // present on {"type":"error","message":…}
+    /// The game's Glk timer request, present only when it CHANGES: a number
+    /// (re)starts the interval, null cancels. nil here = no change this update.
+    let timer: TimerUpdate?
+
+    enum TimerUpdate: Equatable { case set(ms: Int); case cancel }
+
+    enum CodingKeys: String, CodingKey {
+        case type, gen, windows, content, input, specialinput, disable, message, timer
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        type = try c.decode(String.self, forKey: .type)
+        gen = try c.decodeIfPresent(Int.self, forKey: .gen)
+        windows = try c.decodeIfPresent([GlkWindow].self, forKey: .windows)
+        content = try c.decodeIfPresent([GlkContent].self, forKey: .content)
+        input = try c.decodeIfPresent([GlkInput].self, forKey: .input)
+        specialinput = try c.decodeIfPresent(GlkSpecialInput.self, forKey: .specialinput)
+        disable = try c.decodeIfPresent(Bool.self, forKey: .disable)
+        message = try c.decodeIfPresent(String.self, forKey: .message)
+        // Distinguish "timer": N (set) from "timer": null (cancel) from absent
+        // (no change) -- a plain Int? can't, so check key presence explicitly.
+        if c.contains(.timer) {
+            if let ms = try c.decodeIfPresent(Int.self, forKey: .timer) {
+                timer = .set(ms: ms)
+            } else {
+                timer = .cancel
+            }
+        } else {
+            timer = nil
+        }
+    }
 }
 
 /// A file-reference prompt: the game called save/restore and RemGlk is waiting
@@ -117,6 +149,8 @@ enum GlkEvent {
     case char(gen: Int, window: Int, value: String)
     case hyperlink(gen: Int, window: Int, value: Int)
     case redraw(gen: Int)
+    /// Deliver a Glk timer tick (the game requested timer events).
+    case timer(gen: Int)
     /// Answer a `fileref_prompt` (save/restore). `value` is the bare filename
     /// the player chose; RemGlk confines it to the game's sandbox dir and
     /// appends ".glksave". An empty value cancels (no file -> the game reports
@@ -138,6 +172,8 @@ enum GlkEvent {
             return ["type": "hyperlink", "gen": gen, "window": window, "value": value]
         case let .redraw(gen):
             return ["type": "redraw", "gen": gen]
+        case let .timer(gen):
+            return ["type": "timer", "gen": gen]
         case let .specialResponse(gen, value):
             return ["type": "specialresponse", "gen": gen,
                     "response": "fileref_prompt", "value": value]
@@ -161,8 +197,14 @@ enum GlkEvent {
         case let .char(_, w, v):      return .char(gen: gen, window: w, value: v)
         case let .hyperlink(_, w, v): return .hyperlink(gen: gen, window: w, value: v)
         case .redraw:                 return .redraw(gen: gen)
+        case .timer:                  return .timer(gen: gen)
         case let .specialResponse(_, v): return .specialResponse(gen: gen, value: v)
         }
+    }
+
+    var isTimer: Bool {
+        if case .timer = self { return true }
+        return false
     }
 
     /// JSON bytes for this event, newline-terminated. RemGlk reads one


### PR DESCRIPTION
Both apps advertised `"timer"` support but never delivered ticks, so a game that calls `glk_request_timer_events` (JACL's `timer N`) — like the Game of Life demo's auto-run — would just sit still. This wires it up.

## What
- The update's `"timer"` field appears only when the game **changes** its timer: a number (re)starts the interval, `null` cancels, absent = no change.
  - **Android** reads it with `JSONObject.has()`/`isNull()`.
  - **iOS** needs a custom `Decodable` for `GlkUpdate` — a plain `Int?` can't distinguish present-`null` (cancel) from absent (no change).
- While a timer is set, post a `{"type":"timer","gen":N}` event every interval, **coalesced** to one pending tick so a slow turn can't pile them up. Cancelled on `null`, on leaving the game, and on Restart.

## Verified (Android emulator, Game of Life test build)
- `god` seeds the board → `start` → the board **evolves every 500 ms with no input** (consecutive frames differ).
- `stop` → board **frozen** (board-region screenshots identical; only the input cursor blinks).

iOS builds clean and mirrors the same bridge logic.

## On "graphics windows" (the other item discussed)
Investigated and **dropped**: JACL never opens a `wintype_Graphics` window anywhere in the interpreter or libraries — its `image` command draws **inline** in the buffer (`glk_image_draw(mainwin, …, imagealign_InlineDown)`), which both apps already render. So there was nothing to build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)